### PR TITLE
Added `/audit`, modified type hints and more.

### DIFF
--- a/cogs/general.py
+++ b/cogs/general.py
@@ -38,7 +38,7 @@ import core
 
 # The actual cog.
 class General(commands.Cog):
-    def __init__(self, bot: core.bot.IgKnite) -> None:
+    def __init__(self, bot: core.IgKnite) -> None:
         self.bot = bot
 
     @commands.slash_command(
@@ -85,5 +85,5 @@ class General(commands.Cog):
 
 
 # The setup() function for the cog.
-def setup(bot: core.bot.IgKnite) -> None:
+def setup(bot: core.IgKnite) -> None:
     bot.add_cog(General(bot))

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -43,7 +43,7 @@ class General(commands.Cog):
 
     @commands.slash_command(
         name='avatar',
-        description='Displays the avatar / profile picture of a server member.',
+        description='Displays your avatar / the avatar of a server member.',
         options=[
             Option('member', 'Mention the server member.', OptionType.user)
         ],

--- a/cogs/inspection.py
+++ b/cogs/inspection.py
@@ -122,7 +122,7 @@ class Inspection(commands.Cog):
         name='roleinfo',
         description='Shows all important information related to a specific role.',
         options=[
-            Option('role', 'Mention the role.', OptionType.role)
+            Option('role', 'Mention the role.', OptionType.role, required=True)
         ],
         dm_permission=False
     )
@@ -152,6 +152,32 @@ class Inspection(commands.Cog):
         embed.title = f"Role Information: @{role.name}"
 
         await inter.send(embed=embed)
+
+    @commands.slash_command(
+        name='audit',
+        description='Views the latest entries of the audit log in detail.',
+        options=[
+            Option("limit", "The limit for showing audit log entries. Has to be within 1 and 100.", OptionType.integer)
+        ],
+        dm_permission=False
+    )
+    @commands.has_any_role(LockRoles.mod, LockRoles.admin)
+    async def _audit(self, inter: disnake.CommandInter, limit: int = 5):
+        if limit not in range(1, 101):
+            await inter.send(f'{limit} is not within the given range.', ephemeral=True)
+
+        else:
+            embed = core.embeds.ClassicEmbed(inter)
+            embed.title = f'Audit Log ({limit} entries)'
+
+            async for audit_entry in inter.guild.audit_logs(limit=limit):
+                embed.add_field(
+                    name=f'- {audit_entry.action}',
+                    value=f'User: {audit_entry.user} | Target: {audit_entry.target}',
+                    inline=False
+                )
+
+            await inter.send(embed=embed, ephemeral=True)
 
 
 # The setup() function for the cog.

--- a/cogs/inspection.py
+++ b/cogs/inspection.py
@@ -39,7 +39,7 @@ from core.dataclasses import LockRoles
 
 # The actual cog.
 class Inspection(commands.Cog):
-    def __init__(self, bot: core.bot.IgKnite) -> None:
+    def __init__(self, bot: core.IgKnite) -> None:
         self.bot = bot
 
     @commands.slash_command(
@@ -155,5 +155,5 @@ class Inspection(commands.Cog):
 
 
 # The setup() function for the cog.
-def setup(bot: core.bot.IgKnite) -> None:
+def setup(bot: core.IgKnite) -> None:
     bot.add_cog(Inspection(bot))

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -37,7 +37,7 @@ from core.dataclasses import LockRoles
 
 # The actual cog.
 class Moderation(commands.Cog):
-    def __init__(self, bot: core.bot.IgKnite) -> None:
+    def __init__(self, bot: core.IgKnite) -> None:
         self.bot = bot
 
     @commands.slash_command(
@@ -85,5 +85,5 @@ class Moderation(commands.Cog):
 
 
 # The setup() function for the cog.
-def setup(bot: core.bot.IgKnite) -> None:
+def setup(bot: core.IgKnite) -> None:
     bot.add_cog(Moderation(bot))

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -27,9 +27,10 @@ SOFTWARE.
 
 
 # Initialize scripts.
-from . import bot as bot, dataclasses as dataclasses, embeds as embeds, global_ as global_
+from . import dataclasses as dataclasses, embeds as embeds, global_ as global_
+from .bot import *
 
 
 # Set version number.
-__version_info__ = ('2022', '8', '10')  # Year.Month.Day
+__version_info__ = ('2022', '8', '14')  # Year.Month.Day
 __version__ = '.'.join(__version_info__)


### PR DESCRIPTION
### Things changed:

- [x] Added a new `/audit` slash command which can read audit log entries up to a hundred.
- [x] Simplified a type hint (`core.bot.IgKnite` -> `core.IgKnite`)
- [x] Slightly modified the `/avatar` command's description.