### PR TITLE
Added skip and volume buttons to the `/now` slash command.

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -285,8 +285,6 @@ class NowCommandView(disnake.ui.View):
         inter: disnake.Interaction
     ) -> None:
         self.inter.voice_state.skip()
-        button.label = 'Skipped'
-        button.style = disnake.ButtonStyle.gray
 
         await inter.response.edit_message(
             content='Song skipped!',  # only keeping the content and removing everything else (e.g. embed, view)

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -257,6 +257,9 @@ class NowCommandView(disnake.ui.View):
 
         self.inter = inter
         self.add_item(disnake.ui.Button(label='Redirect', url=url))
+        volume_button = disnake.ui.Button(label=f'Volume: {int(inter.voice_state.volume*100)}')
+        volume_button.disabled = True
+        self.add_item(volume_button)
 
     @disnake.ui.button(label='Toggle Loop', style=disnake.ButtonStyle.gray)
     async def _loop(
@@ -274,6 +277,22 @@ class NowCommandView(disnake.ui.View):
             button.style = disnake.ButtonStyle.green
 
         await inter.response.edit_message(view=self)
+
+    @disnake.ui.button(label='Skip', style=disnake.ButtonStyle.red)
+    async def _skip(
+        self,
+        button: disnake.ui.Button,
+        inter: disnake.Interaction
+    ) -> None:
+        self.inter.voice_state.skip()
+        button.label = 'Skipped'
+        button.style = disnake.ButtonStyle.gray
+
+        await inter.response.edit_message(
+            content='Song skipped!',  # only keeping the content and removing everything else (e.g. embed, view)
+            view=None,
+            embed=None
+        )
 
     async def on_timeout(self) -> None:
         for children in self.children:


### PR DESCRIPTION
Current UI:
![image](https://user-images.githubusercontent.com/35540227/193472525-f27832fa-0c9f-47db-8eb8-220a58dbc140.png)

After pressing skip:
![image](https://user-images.githubusercontent.com/35540227/193472530-a6cf3e20-7702-4f8b-ab2e-0542b8479455.png)

Issue: #48 

Let me know your thoughts on this.