### PR TITLE
Modifications to the newly added `/ping` command and more.

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: 💡 General Feature Request
-description: Have a new idea/feature for Milan? Please suggest!
+description: Have a new idea/feature for IgKnite? Please suggest!
 title: "[FEATURE] <description>"
 labels: ["feat"]
 body:

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -20,12 +20,10 @@ from core import global_
 from core.embeds import TypicalEmbed
 
 
-# Backend for the `ping` command.
-async def _ping_backend(
-    inter: disnake.CommandInteraction,
-    bot: core.IgKnite,
-) -> TypicalEmbed:
-    system_latency = round(bot.latency * 1000)
+# Backend for userinfo-labelled commands.
+# Do not use it within other commands unless really necessary.
+async def _ping_backend(inter: disnake.CommandInteraction) -> TypicalEmbed:
+    system_latency = round(inter.bot.latency * 1000)
 
     start_time = time.time()
     await inter.response.defer()
@@ -38,7 +36,7 @@ async def _ping_backend(
 
     embed = core.TypicalEmbed(inter).add_field(
         name='System Latency',
-        value=f'{system_latency}ms [{bot.shard_count} shard(s)]',
+        value=f'{system_latency}ms [{inter.bot.shard_count} shard(s)]',
         inline=False
     ).add_field(
         name='API Latency',
@@ -57,20 +55,18 @@ class PingCommandView(disnake.ui.View):
     def __init__(
         self,
         inter: disnake.CommandInteraction,
-        bot: core.IgKnite,
         timeout: float = 60
     ) -> None:
         super().__init__(timeout=timeout)
         self.inter = inter
-        self.bot = bot
 
-    @disnake.ui.button(emoji='🔄', style=disnake.ButtonStyle.green)
+    @disnake.ui.button(label='Refresh', style=disnake.ButtonStyle.gray)
     async def _refresh(
         self,
-        button: disnake.ui.Button,
+        _: disnake.ui.Button,
         inter: disnake.Interaction
     ) -> None:
-        embed = await _ping_backend(bot=self.bot, inter=inter)
+        embed = await _ping_backend(inter)
         await inter.edit_original_message(embed=embed, view=self)
 
 
@@ -137,9 +133,8 @@ class General(commands.Cog):
         self,
         inter: disnake.CommandInteraction
     ) -> None:
-        view = PingCommandView(bot=self.bot, inter=inter)
-        embed = await _ping_backend(bot=self.bot, inter=inter)
-        await inter.send(embed=embed, view=view)
+        embed = await _ping_backend(inter)
+        await inter.send(embed=embed, view=PingCommandView(inter=inter))
 
 
 # The setup() function for the cog.

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -34,7 +34,10 @@ async def _ping_backend(inter: disnake.CommandInteraction) -> TypicalEmbed:
     uptime = round(datetime.timestamp(datetime.now())) - global_.running_since
     h, m, s = uptime // 3600, uptime % 3600 // 60, uptime % 3600 % 60
 
-    embed = core.TypicalEmbed(inter).add_field(
+    embed = core.TypicalEmbed(
+        inter=inter,
+        disabled_footer=True
+    ).add_field(
         name='System Latency',
         value=f'{system_latency}ms [{inter.bot.shard_count} shard(s)]',
         inline=False
@@ -92,6 +95,7 @@ class General(commands.Cog):
         ).set_image(
             url=member.avatar
         )
+
         await inter.send(embed=embed)
 
     @commands.slash_command(

--- a/cogs/inspection.py
+++ b/cogs/inspection.py
@@ -380,8 +380,11 @@ class Inspection(commands.Cog):
         await inter.send(
             embed=embed,
             view=InviteCommandView(
-                inter, load_page, top_page,
-                page, await inter.guild.invites()
+                inter=inter,
+                page_loader=load_page,
+                top_page=top_page,
+                page=page,
+                invites=await inter.guild.invites()
             ) if invites else MISSING
         )
 

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -816,7 +816,7 @@ class Music(commands.Cog):
         if len(inter.voice_state.songs) == 0:
             return await inter.send('The queue is empty.')
 
-        view = QueueCommandView(inter)
+        view = QueueCommandView(inter=inter)
         await inter.send(view=view)
 
     # rmqueue

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -14,5 +14,5 @@ from .embeds import *
 
 
 # Set version number.
-__version_info__ = ('2022', '9', '3')  # Year.Month.Day
+__version_info__ = ('2022', '10', '11')  # Year.Month.Day
 __version__ = '.'.join(__version_info__)

--- a/core/embeds.py
+++ b/core/embeds.py
@@ -21,24 +21,27 @@ class TypicalEmbed(disnake.Embed):
     def __init__(
         self,
         inter: disnake.CommandInteraction,
+        *,
+        disabled_footer: bool = False,
         is_error: bool = False
     ) -> None:
         super().__init__(
             color=(3158326 if not is_error else 16608388)
         )
 
-        self.set_footer(
-            text=random.choice(
-                [
-                    'When pigs fly...',
-                    'Stunned stork!',
-                    'A perfect debugged life doesn\'t exist.',
-                    'Haven\'t I made it obvious?',
-                    'Hello World, from the other side!'
-                ]
-            ),
-            icon_url=inter.author.avatar
-        )
+        if not disabled_footer:
+            self.set_footer(
+                text=random.choice(
+                    [
+                        'When pigs fly...',
+                        'Stunned stork!',
+                        'A perfect debugged life doesn\'t exist.',
+                        'Haven\'t I made it obvious?',
+                        'Hello World, from the other side!'
+                    ]
+                ),
+                icon_url=inter.author.avatar
+            )
 
     def set_title(self, value: str) -> None:
         '''

--- a/core/global_.py
+++ b/core/global_.py
@@ -57,8 +57,10 @@ def initialize() -> None:
         exit()
 
     else:
+        # global variable to store start time
         global running_since
         running_since = round(datetime.timestamp(datetime.now()))
-        # global variable (list) for storing sniped messages
+
+        # global variable to store sniped messages
         global snipeables
         snipeables = []


### PR DESCRIPTION
### Things changed:

- [x] The `/ping` slash command now contains a simplified embed and view, with a "Refresh" gray-labelled button instead of an emoji.
- [x] The `/ping` slash command now has less `self` calls overall.
- [x] `core.embeds.TypicalEmbed` now have a `disabled_footer` parameter which can be used to disable the integrated random footers. This is ignored by default and set to False.
- [x] Synced comments for command backends.
- [x] Replaced the "Milan" noun inside an issue template with "IgKnite". Probably someone forgot to remove it :P

... and some more teeny-tiny changes.