### PR TITLE
Improved `/playrich` command family and implemented Docker Compose.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,5 @@ RUN apt-get -y update && apt-get -y upgrade && apt-get install -y --no-install-r
 # Copy project files to working directory.
 COPY . .
 
-# Run.
-CMD [ "python", "main.py" ]
+# Real-time project view.
+ENV PYTHONUNBUFFERED 1

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -20,7 +20,7 @@ from core import global_
 from core.embeds import TypicalEmbed
 
 
-# Backend for userinfo-labelled commands.
+# Backend for ping-labelled commands.
 # Do not use it within other commands unless really necessary.
 async def _ping_backend(inter: disnake.CommandInteraction) -> TypicalEmbed:
     system_latency = round(inter.bot.latency * 1000)
@@ -81,7 +81,7 @@ class General(commands.Cog):
     ) -> None:
         self.bot = bot
 
-    # Backend for userinfo-labelled commands.
+    # Backend for avatar-labelled commands.
     # Do not use it within other commands unless really necessary.
     async def _avatar_backend(
         self,
@@ -98,6 +98,7 @@ class General(commands.Cog):
 
         await inter.send(embed=embed)
 
+    # avatar (slash)
     @commands.slash_command(
         name='avatar',
         description='Displays your avatar / the avatar of a server member.',

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -1026,7 +1026,9 @@ class Music(commands.Cog):
         for activity in member.activities:
             if isinstance(activity, disnake.Spotify):
                 track = Spotify.get_track_features(activity.track_id)
-                await self._play_backend(inter, track)
+                return await self._play_backend(inter, track)
+
+        await inter.send('Nothing is being played on Spotify!')
 
     # playrich (slash)
     @commands.slash_command(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+services:
+  bot:
+    build: .
+    command: bash -c "python main.py"
+    container_name: igknite
+    volumes:
+      - .:/app


### PR DESCRIPTION
### Things changed:

- [x] Added a new "Rich Play" user command which is essentially the user version of the `/playrich` slash command.
- [x] Having no Spotify rich presence now throws an interaction message.
- [x] The project now uses [Docker Compose](https://docs.docker.com/compose/) to run. The documentation for self-hosting will be updated accordingly if this PR is merged.
- [x] Some typos inside the General cog (`cogs/general.py`) related to command backends have been fixed.