### PR TITLE
Removed `/pinlast` and the selection menu for `/invites` (+ more).

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -352,34 +352,6 @@ class Moderation(commands.Cog):
         else:
             await inter.send('There are no pins to clear!', ephemeral=True)
 
-    # pins the last message
-    @commands.slash_command(
-        name='pinlast',
-        description='Pins the last message by a user to the channel.',
-        dm_permission=False,
-        options=[
-            Option(
-                'member', 'Mention the server member.', OptionType.user, required=True
-            )
-        ],
-    )
-    @commands.has_any_role(LockRoles.mod, LockRoles.admin)
-    async def _pin(
-        self, inter: disnake.CommandInteraction, member: disnake.Member
-    ) -> None:
-        async for message in inter.channel.history():
-            if message.author == member:
-                await message.pin()
-                embed = (
-                    core.TypicalEmbed(inter)
-                    .set_title(value=f'Pinned {message.author.name}\'s message:')
-                    .set_description(
-                        value=f'{message.content} \n\n [Jump to message]({message.jump_url})'
-                    )
-                )
-                await inter.send(embed=embed, ephemeral=True)
-                break
-
 
 # The setup() function for the cog.
 def setup(bot: core.IgKnite) -> None:


### PR DESCRIPTION
### Things changed:

- [x] Removed the `/pinlast` slash command as it wasn't found useful. A message / user variant of it might reappear soon.
- [x] Removed the selection menu inside the view of the `/invites` slash command. It'll shortly be replaced by a new command soon.
- [x] Modified type annotations and function calls.