### PR TITLE
Added choices to `/slowmode` and separated workflows.

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -5,38 +5,39 @@ on:
     branches:
       - main
 
-format:
-  name: black
-  runs-on: ubuntu-latest
+jobs:
+  format:
+    name: black
+    runs-on: ubuntu-latest
 
-  steps:
-    - name: Checkout
-      uses: actions/checkout@v3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
-    - name: Check
-      id: checkifneeded
-      uses: psf/black@stable
-      with:
-        options: "--check --verbose --skip-string-normalization"
-        version: "~= 22.0"
-      continue-on-error: true
+      - name: Check
+        id: checkifneeded
+        uses: psf/black@stable
+        with:
+          options: "--check --verbose --skip-string-normalization"
+          version: "~= 22.0"
+        continue-on-error: true
 
-    - name: Format
-      uses: psf/black@stable
-      with:
-        options: "--verbose --skip-string-normalization"
-        version: "~= 22.0"
+      - name: Format
+        uses: psf/black@stable
+        with:
+          options: "--verbose --skip-string-normalization"
+          version: "~= 22.0"
 
-    - name: Create pull request
-      if: steps.checkifneeded.outcome != 'success'
-      uses: peter-evans/create-pull-request@v4
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        title: "Resolved formatting errors"
-        commit-message: "format code using psf/black"
-        body: |
-          Formatter errors found in: ${{ github.sha }}.
-        base: ${{ github.head_ref }}
-        branch: actions/black
-        reviewers: hitblast
-        delete-branch: true
+      - name: Create pull request
+        if: steps.checkifneeded.outcome != 'success'
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: "Resolved formatting errors"
+          commit-message: "format code using psf/black"
+          body: |
+            Formatter errors found in: ${{ github.sha }}.
+          base: ${{ github.head_ref }}
+          branch: actions/black
+          reviewers: hitblast
+          delete-branch: true

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -1,0 +1,42 @@
+name: Format
+
+on:
+  push:
+    branches:
+      - main
+
+format:
+  name: black
+  runs-on: ubuntu-latest
+
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Check
+      id: checkifneeded
+      uses: psf/black@stable
+      with:
+        options: "--check --verbose --skip-string-normalization"
+        version: "~= 22.0"
+      continue-on-error: true
+
+    - name: Format
+      uses: psf/black@stable
+      with:
+        options: "--verbose --skip-string-normalization"
+        version: "~= 22.0"
+
+    - name: Create pull request
+      if: steps.checkifneeded.outcome != 'success'
+      uses: peter-evans/create-pull-request@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        title: "Resolved formatting errors"
+        commit-message: "format code using psf/black"
+        body: |
+          Formatter errors found in: ${{ github.sha }}.
+        base: ${{ github.head_ref }}
+        branch: actions/black
+        reviewers: hitblast
+        delete-branch: true

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,4 +1,4 @@
-name: Lint & Format
+name: Lint
 
 on:
   push:
@@ -24,39 +24,3 @@ jobs:
 
       - name: Run flake8
         uses: py-actions/flake8@v2
-
-  format:
-    name: black
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Check
-        id: checkifneeded
-        uses: psf/black@stable
-        with:
-          options: "--check --verbose --skip-string-normalization"
-          version: "~= 22.0"
-        continue-on-error: true
-
-      - name: Format
-        uses: psf/black@stable
-        with:
-          options: "--verbose --skip-string-normalization"
-          version: "~= 22.0"
-
-      - name: Create pull request
-        if: steps.checkifneeded.outcome != 'success'
-        uses: peter-evans/create-pull-request@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          title: "Resolved formatting errors"
-          commit-message: "format code using psf/black"
-          body: |
-            Formatter errors found in: ${{ github.sha }}.
-          base: ${{ github.head_ref }}
-          branch: actions/black
-          reviewers: hitblast
-          delete-branch: true

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -9,7 +9,7 @@ https://github.com/IgKniteDev/IgKnite/blob/main/LICENSE
 
 # Imports.
 import disnake
-from disnake import Option, OptionType
+from disnake import Option, OptionType, OptionChoice
 from disnake.ext import commands
 
 import core
@@ -355,22 +355,37 @@ class Moderation(commands.Cog):
     # slowmode
     @commands.slash_command(
         name='slowmode',
-        description='Sets the slowmode of the current channel.',
+        description='Sets slowmode for the current channel.',
         options=[
             Option(
                 'seconds',
-                'The amount of seconds to set the slowmode to, 0 to disable.',
+                'The amount of seconds to set the slowmode to. Set 0 to disable.',
                 OptionType.integer,
                 min_value=0,
                 max_value=21600,
-                required=False,
+                choices=[
+                    OptionChoice('5s', 5),
+                    OptionChoice('10s', 10),
+                    OptionChoice('15s', 15),
+                    OptionChoice('30s', 30),
+                    OptionChoice('1m', 60),
+                    OptionChoice('2m', 120),
+                    OptionChoice('5m', 300),
+                    OptionChoice('10m', 600),
+                    OptionChoice('15m', 900),
+                    OptionChoice('30m', 1800),
+                    OptionChoice('1h', 3600),
+                    OptionChoice('2h', 7200),
+                    OptionChoice('6h', 21600)
+                ],
+                required=True
             )
         ],
         dm_permission=False,
     )
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
     async def _slowmode(
-        self, inter: disnake.CommandInteraction, seconds: int = 30
+        self, inter: disnake.CommandInteraction, seconds: int
     ) -> None:
         await inter.channel.edit(slowmode_delay=seconds)
         await inter.send(f'Slowmode has been set to **{seconds}** seconds.')

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -14,7 +14,7 @@ from .embeds import *
 
 
 # Set version number.
-__version_info__ = ('2022', '10', '19')  # Year.Month.Day
+__version_info__ = ('2022', '10', '20')  # Year.Month.Day
 __version__ = '.'.join(__version_info__)
 
 


### PR DESCRIPTION
### Things changed:

- [x] The `/slowmode` slash command now has built-in choices ranging from 5s to 6h to choose from.
- [x] Limited formatting workflows for [black](https://github.com/psf/black) so that they only trigger upon pushes to the `main` branch. This is due to a limitation introduced by GitHub itself (explicit permissions for workflows to create pull requests on forks and/or other branches).