### PR TITLE
refact: use or operator instead of ternay

### DIFF
--- a/cogs/general.py
+++ b/cogs/general.py
@@ -79,7 +79,7 @@ class General(commands.Cog):
     async def _avatar_backend(
         self, inter: disnake.CommandInteraction, member: disnake.Member = None
     ) -> None:
-        member =  member or inter.author
+        member = member or inter.author
 
         embed = (
             core.TypicalEmbed(inter)

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -79,7 +79,7 @@ class General(commands.Cog):
     async def _avatar_backend(
         self, inter: disnake.CommandInteraction, member: disnake.Member = None
     ) -> None:
-        member = inter.author if not member else member
+        member =  member or inter.author
 
         embed = (
             core.TypicalEmbed(inter)

--- a/cogs/inspection.py
+++ b/cogs/inspection.py
@@ -123,7 +123,7 @@ class Inspection(commands.Cog):
     async def _userinfo_backend(
         self, inter: disnake.CommandInteraction, member: disnake.Member = None
     ) -> None:
-        member = inter.author if not member else member
+        member = member or inter.author
 
         embed = (
             core.TypicalEmbed(inter)

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -374,7 +374,7 @@ class Song:
     def create_embed(
         self, inter: disnake.CommandInteraction
     ) -> Tuple[core.TypicalEmbed, disnake.ui.View]:
-        duration = 'Live' if not self.source.duration else self.source.duration
+        duration = self.source.duration or 'Live'
 
         embed = (
             core.TypicalEmbed(inter)


### PR DESCRIPTION
### Things changed:

- [x] Verify if member exists else use inter.author with or operator.
- [x] Verify if self.source.duration exists else use "Live" by default with or operator.