### PR TITLE
bugfix: `/ripplepurge` backend message and error handler

### DIFF
--- a/cogs/exceptionhandler.py
+++ b/cogs/exceptionhandler.py
@@ -10,10 +10,11 @@ https://github.com/IgKniteDev/IgKnite/blob/main/LICENSE
 # Imports.
 from typing import Any
 
-import core
 import disnake
 from disnake import errors
 from disnake.ext import commands
+
+import core
 
 
 # The actual cog.
@@ -38,7 +39,7 @@ class ExceptionHandler(commands.Cog):
         if isinstance(error, commands.errors.MissingPermissions) or isinstance(
             error, errors.Forbidden
         ):
-            embed.set_title('Nice try! You don\'t have permission to do that.')
+            embed.set_title('Nice try! I don\'t have permission to do that.')
 
         # MissingRole
         elif isinstance(error, commands.errors.MissingRole) or isinstance(
@@ -61,7 +62,7 @@ class ExceptionHandler(commands.Cog):
         if isinstance(error, commands.errors.MissingPermissions) or isinstance(
             error, errors.Forbidden
         ):
-            embed.set_title('Nice try! You don\'t have permission to do that.')
+            embed.set_title('Nice try! I don\'t have permission to do that.')
 
         # MissingRole
         elif isinstance(error, commands.errors.MissingRole) or isinstance(
@@ -84,7 +85,7 @@ class ExceptionHandler(commands.Cog):
         if isinstance(error, commands.errors.MissingPermissions) or isinstance(
             error, errors.Forbidden
         ):
-            embed.set_title('Nice try! You don\'t have permission to do that.')
+            embed.set_title('Nice try! I don\'t have permission to do that.')
 
         # MissingRole
         elif isinstance(error, commands.errors.MissingRole) or isinstance(

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -203,7 +203,7 @@ class Moderation(commands.Cog):
 
         await inter.channel.delete_messages(messages)
         await inter.send(
-            f'Purged 10 messages that were sent by **{member.display_name}.**',
+            f'Purged {len(messages)} messages that were sent by **{member.display_name}.**',
             ephemeral=True,
         )
 


### PR DESCRIPTION
This micro-PR fixes a tiny yet urgent bug which hardcoded the number "10" as the purged amount within the notification message for ripple purge command group. It also fixes some message lines in the exception handler.