### PR TITLE
bugfix: webhooks don't get deleted after using the `/snipe` command

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -272,9 +272,9 @@ class Moderation(commands.Cog):
                         username=snipeable.author.display_name,
                         avatar_url=snipeable.author.avatar,
                     )
+                    await webhook.delete()
                     sniped_count += 1
 
-            await webhook.delete()
             await inter.send(f'Sniped **{sniped_count}** messages.', ephemeral=True)
 
         else:


### PR DESCRIPTION
### Things changed:

- [x] Fixed #158 