### PR TITLE
chore: Properly reused webhooks inside `/snipe` command

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -16,7 +16,7 @@ from .bot import *
 from .embeds import *
 
 # Set version number.
-__version_info__ = ('2022', '12', '16')  # Year.Month.Day
+__version_info__ = ('2022', '12', '22')  # Year.Month.Day
 __version__ = '.'.join(__version_info__)
 
 # Set bot metadata.


### PR DESCRIPTION
### Things changed:

- Previous webhooks are used for sniping user messages if the authors match in order.