### PR TITLE
[tuning] Better overall `/snipe` command operation and more

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -545,8 +545,7 @@ class Music(commands.Cog):
 
         except AttributeError:
             await inter.send(
-                'Please switch to a voice or stage channel to use this command.',
-                ephemeral=True,
+                'Please switch to a voice or stage channel to use this command.', ephemeral=True
             )
 
     # join
@@ -784,11 +783,14 @@ class Music(commands.Cog):
         try:
             source = await YTDLSource.create_source(inter, keyword, loop=self.bot.loop)
 
-        except YTDLError as e:
-            await inter.send(
-                f'An error occurred while processing this request: {str(e)}',
-                ephemeral=True,
-            )
+        except Exception as e:
+            if isinstance(e, YTDLError):
+                await inter.send(
+                    f'An error occurred while processing this request: {str(e)}',
+                    ephemeral=True,
+                )
+            else:
+                pass
 
         else:
             song = Song(source)
@@ -816,10 +818,7 @@ class Music(commands.Cog):
         dm_permission=False,
     )
     async def _play(self, inter: disnake.CommandInteraction, keyword: str) -> None:
-        if 'https://open.spotify.com/playlist/' in keyword or 'spotify:playlist:' in keyword:
-            ids = Spotify.get_playlist_track_ids(keyword)
-            tracks = []
-
+        async def process_spotify_tracks(ids, tracks) -> None:
             for i in range(len(ids)):
                 track = Spotify.get_track_features(ids[i])
                 tracks.append(track)
@@ -831,22 +830,18 @@ class Music(commands.Cog):
                 value=f'{len(tracks)} tracks have been queued!'
             )
             await inter.send(embed=embed)
+
+        if 'https://open.spotify.com/playlist/' in keyword or 'spotify:playlist:' in keyword:
+            ids = Spotify.get_playlist_track_ids(keyword)
+            tracks = []
+
+            await process_spotify_tracks(ids, tracks)
 
         elif 'https://open.spotify.com/album/' in keyword or 'spotify:album:' in keyword:
             ids = Spotify.get_album(keyword)
             tracks = []
 
-            for i in range(len(ids)):
-                track = Spotify.get_track_features(ids[i])
-                tracks.append(track)
-
-            for track in tracks:
-                await self._play_backend(inter, track, send_embed=False)
-
-            embed = core.TypicalEmbed(inter).set_title(
-                value=f'{len(tracks)} tracks have been queued!'
-            )
-            await inter.send(embed=embed)
+            await process_spotify_tracks(ids, tracks)
 
         elif 'https://open.spotify.com/track/' in keyword or 'spotify:track:' in keyword:
             id = Spotify.get_track_id(keyword)

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -336,7 +336,10 @@ class QueueCommandView(disnake.ui.View):
         await inter.response.edit_message(view=self)
 
     async def on_timeout(self) -> None:
-        await self.inter.delete_original_message()
+        for child in self.children:
+            child.disabled = True
+
+        await self.inter.edit_original_message(view=self)
 
 
 # The Song class which represents the instance of a song.

--- a/core/chain.py
+++ b/core/chain.py
@@ -9,8 +9,10 @@ https://github.com/IgKniteDev/IgKnite/blob/main/LICENSE
 
 # Imports.
 import logging
+from typing import List
 
 from decouple import UndefinedValueError, config
+from disnake import Message
 
 
 # Custom class for handling environment secrets and global variables..
@@ -31,7 +33,7 @@ class KeyChain:
             )
 
         else:
-            self.snipeables = []
+            self.snipeables: List[Message] = []
 
 
 # Initializing it.


### PR DESCRIPTION
### Primary change:

- [x] Everything mentioned in the following issue: https://github.com/IgKniteDev/IgKnite/issues/185

### Other changes:

- [x] The components of the `/queue` command are now disabled upon timeout instead of full deletion.
- [x] Failed enqueueing from Spotify playlists now passes the song instead of crashing the command entirely.
- [x] Reduced some code inside the `/play` slash command.
- [x] Tiny type hinting added inside the `core/chain.py` script.