### PR TITLE
⚡ [tuning] Improved embeds for `/playrich`-based commands & more

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -296,11 +296,7 @@ class Moderation(commands.Cog):
     ) -> None:
         webhooks: List[disnake.Webhook] = []
         snipeables = sorted(
-            [
-                snipeable
-                for snipeable in keychain.snipeables
-                if snipeable.guild.id == inter.guild.id
-            ],
+            [snipeable for snipeable in keychain.snipeables if snipeable.guild == inter.guild],
             key=lambda x: x.created_at.timestamp(),
         )
         sniped_count: int = 0

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -576,7 +576,7 @@ class Music(commands.Cog):
 
         await inter.voice_state.stop()
         del self.voice_states[inter.guild.id]
-        await inter.followup.send('Left voice state.')
+        await inter.send('Left voice state.')
 
     # volume
     @commands.slash_command(
@@ -906,7 +906,16 @@ class Music(commands.Cog):
         for activity in member.activities:
             if isinstance(activity, disnake.Spotify):
                 track = Spotify.get_track_features(activity.track_id)
-                return await self._play_backend(inter, track)
+                await self._play_backend(inter, track, send_embed=False)
+
+                embed = disnake.Embed(
+                    title='Fetched from Spotify!',
+                    description=f'Now attempting to search for **"{track}"** on YouTube'
+                    + ' and enqueue it.',
+                    color=1824608,
+                ).set_image(url=activity.album_cover_url)
+
+                return await inter.send(embed=embed)
 
         await inter.send('Nothing is being played on Spotify!', ephemeral=True)
 

--- a/core/embeds.py
+++ b/core/embeds.py
@@ -48,14 +48,14 @@ class TypicalEmbed(disnake.Embed):
 
     def set_title(self, value: str) -> Self:
         '''
-        Sets the title for the embed content.
+        Sets the title for the embed.
         '''
         self.title = value
         return self
 
     def set_description(self, value: str) -> Self:
         '''
-        Sets the description for the embed content.
+        Sets the description for the embed.
         '''
         self.description = value
         return self


### PR DESCRIPTION
### Things changed:

- [x] Closes: #176 
- [x] Change that one line for guild comparison inside the `/snipe` slash command.
- [x] Modified some docstrings inside the `core/embeds.py` script.