### PR TITLE
✨ [feat] Added new listener for emoji reactions, bookmarking feature

### DIFF
--- a/cogs/general.py
+++ b/cogs/general.py
@@ -74,7 +74,7 @@ class General(commands.Cog):
     # Listener for the bookmark feature.
     @commands.Cog.listener()
     async def on_reaction_add(
-        self, reaction: disnake.Reaction, user: disnake.Member | disnake.User
+        self, reaction: disnake.Reaction, user: disnake.Member
     ) -> None:
         if reaction.emoji == '🔖':
             embed = disnake.Embed(

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -71,6 +71,18 @@ class General(commands.Cog):
     def __init__(self, bot: core.IgKnite) -> None:
         self.bot = bot
 
+    # Listener for the bookmark feature.
+    @commands.Cog.listener()
+    async def on_reaction_add(
+        self, reaction: disnake.Reaction, user: disnake.Member | disnake.User
+    ) -> None:
+        if reaction.emoji == '🔖':
+            embed = disnake.Embed(
+                color=3158326,
+                description=reaction.message.content,
+            ).set_author(name=f'{user.name}#{user.discriminator}', icon_url=user.avatar)
+            await user.send(embed=embed)
+
     # Backend for avatar-labelled commands.
     # Do not use it within other commands unless really necessary.
     async def _avatar_backend(

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -81,7 +81,7 @@ class General(commands.Cog):
                 color=3158326,
                 description=reaction.message.content,
             ).set_author(name=f'{user.name}#{user.discriminator}', icon_url=user.avatar)
-            await user.send(embed=embed)
+            await user.send(content=reaction.message.jump_url, embed=embed)
 
     # Backend for avatar-labelled commands.
     # Do not use it within other commands unless really necessary.


### PR DESCRIPTION
### Things changed:

- [x] Added a new `on_reaction_add` listenerer to the `general` cog. 
- [x] Added a new bookmarking feature, react to a message with `🔖` to bookmark it. (IgKnite will DM you a copy of it alongside a url to the original message.)

One thing to note, I didn't use `TypicalEmbed` for the embed for this one, because it simply didn't work out since `TypicalEmbed` requires an `Interaction` as an argument. 

[Inspiration!](https://git.poto.cafe/yagich/potomark-bot-rb/)