### PR TITLE
🐛 [bug-fixed] Fixed "Rich Play" showing up in DMs as user command

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -932,7 +932,7 @@ class Music(commands.Cog):
         await self._playrich_backend(inter, member)
 
     # playrich (user)
-    @commands.user_command(name='Rich Play', dm_permisision=False)
+    @commands.user_command(name='Rich Play', dm_permission=False)
     async def _playrich_user(
         self, inter: disnake.CommandInteraction, member: disnake.Member
     ) -> None:


### PR DESCRIPTION
### Things changed:

This tiny PR fixes a small typo which allowed the **Rich Play** user command to be available in the users' DMs.