### PR TITLE
🔨 [tuning] Better vote-skips with `/skip` slash command

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -16,7 +16,7 @@ from .bot import *
 from .embeds import *
 
 # Set version number.
-__version_info__ = ('2023', '3', '22')  # Year.Month.Day
+__version_info__ = ('2023', '3', '23')  # Year.Month.Day
 __version__ = '.'.join(__version_info__)
 
 # Set bot metadata.


### PR DESCRIPTION
### Things changed:

- [x] This PR adds **dynamic vote-skips** so that the `/skip` slash command can decide whether to:
        1. skip directly (based on the presence of the requester in the voice channel), or 
        2. to skip with the vote of a given number of users (around half the people who are currently in the voice channel).