### PR TITLE
🔨 [tuning] Improved moderation commands and fixed more minor bugs

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -18,38 +18,6 @@ from core.chain import keychain
 from core.datacls import LockRoles
 
 
-# View for the `clearnicks` command.
-class ClearnickCommandView(disnake.ui.View):
-    def __init__(self, inter: disnake.CommandInteraction, *, timeout: float = 60) -> None:
-        super().__init__(timeout=timeout)
-        self.inter = inter
-
-    @disnake.ui.button(label='Do it!', style=disnake.ButtonStyle.danger)
-    async def _confirm_action(self, _: disnake.ui.Button, inter: disnake.Interaction) -> None:
-        await inter.response.defer()
-
-        if LockRoles.admin in [role.name for role in inter.author.roles]:
-            for member in inter.guild.members:
-                try:
-                    await member.edit(nick=None)
-                except disnake.errors.Forbidden:
-                    pass
-
-            await inter.edit_original_message(
-                'All nicknames have been cleared!', embed=None, view=None
-            )
-
-        else:
-            await inter.edit_original_message('You can\'t do that!', embed=None, view=None)
-
-    async def on_timeout(self) -> None:
-        for child in self.children:
-            if 'Redirect' != child.label:
-                child.disabled = True
-
-        await self.inter.edit_original_message(view=self)
-
-
 # The actual cog.
 class Moderation(commands.Cog):
     def __init__(self, bot: core.IgKnite) -> None:
@@ -203,7 +171,7 @@ class Moderation(commands.Cog):
                 'amount',
                 'The amount of messages to purge. Defaults to 1.',
                 OptionType.integer,
-                min_value=1,
+                min_value=2,
             ),
             Option('onlyme', 'Only deletes messages sent by me.', OptionType.boolean),
         ],
@@ -211,7 +179,7 @@ class Moderation(commands.Cog):
     )
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
     async def _purge(
-        self, inter: disnake.CommandInteraction, amount: int = 1, onlyme: bool = False
+        self, inter: disnake.CommandInteraction, amount: int = 2, onlyme: bool = False
     ) -> None:
         def is_me(message: disnake.Message) -> bool:
             return message.author == self.bot.user
@@ -417,6 +385,7 @@ class Moderation(commands.Cog):
                 min_value=0,
                 max_value=21600,
                 choices=[
+                    OptionChoice('Remove Slowmode', 0),
                     OptionChoice('5s', 5),
                     OptionChoice('10s', 10),
                     OptionChoice('15s', 15),
@@ -552,13 +521,16 @@ class Moderation(commands.Cog):
     )
     @commands.has_any_role(LockRoles.admin)
     async def _clearnicks(self, inter: disnake.CommandInteraction) -> None:
-        embed = (
-            core.TypicalEmbed(inter, disabled_footer=True, is_error=True)
-            .set_title('Are you sure?')
-            .set_description('This action cannot be undone.')
-        )
+        deletion_count = 0
 
-        await inter.send(embed=embed, view=ClearnickCommandView(inter), ephemeral=True)
+        for member in inter.guild.members:
+            try:
+                await member.edit(nick=None)
+                deletion_count += 1
+            except disnake.errors.Forbidden:
+                pass
+
+        await inter.send(f'Cleared the nicknames for **{deletion_count}** users.')
 
 
 # The setup() function for the cog.

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -171,7 +171,7 @@ class Moderation(commands.Cog):
                 'amount',
                 'The amount of messages to purge. Defaults to 1.',
                 OptionType.integer,
-                min_value=2,
+                min_value=1,
             ),
             Option('onlyme', 'Only deletes messages sent by me.', OptionType.boolean),
         ],
@@ -179,10 +179,12 @@ class Moderation(commands.Cog):
     )
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
     async def _purge(
-        self, inter: disnake.CommandInteraction, amount: int = 2, onlyme: bool = False
+        self, inter: disnake.CommandInteraction, amount: int = 1, onlyme: bool = False
     ) -> None:
         def is_me(message: disnake.Message) -> bool:
             return message.author == self.bot.user
+
+        amount += 1
 
         if onlyme:
             await inter.channel.purge(limit=amount, check=is_me)

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -426,7 +426,7 @@ class Moderation(commands.Cog):
         ],
         dm_permission=False,
     )
-    @commands.has_any_role(LockRoles.admin)
+    @commands.has_role(LockRoles.admin)
     async def _banword(self, inter: disnake.CommandInteraction, keywords: str) -> None:
         keywords = keywords.split(',')
 
@@ -471,7 +471,7 @@ class Moderation(commands.Cog):
         description='Clears the list of banned keywords added by me.',
         dm_permission=False,
     )
-    @commands.has_any_role(LockRoles.admin)
+    @commands.has_role(LockRoles.admin)
     async def _clearbannedwords(self, inter: disnake.CommandInteraction) -> None:
         try:
             for rule in await inter.guild.fetch_automod_rules():
@@ -493,7 +493,7 @@ class Moderation(commands.Cog):
         description='Shows the list of banned keywords added by me.',
         dm_permission=False,
     )
-    @commands.has_any_role(LockRoles.admin)
+    @commands.has_role(LockRoles.admin)
     async def _showbannedwords(self, inter: disnake.CommandInteraction) -> None:
         try:
             words = ''
@@ -521,7 +521,7 @@ class Moderation(commands.Cog):
         description='Clear everyone\'s nickname in the guild.',
         dm_permission=False,
     )
-    @commands.has_any_role(LockRoles.admin)
+    @commands.has_role(LockRoles.admin)
     async def _clearnicks(self, inter: disnake.CommandInteraction) -> None:
         deletion_count = 0
 

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -176,6 +176,7 @@ class YTDLSource(disnake.PCMVolumeTransformer):
 
 
 # YTDLSource class with equalized playback.
+# Note: This feature is still work-in-progress and the audio filters need to be improved.
 class YTDLSourceBoosted(YTDLSource):
     '''
     A child class of `YTDLSource` for serving equalized playback.

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -441,6 +441,7 @@ class QueueCommandView(disnake.ui.View):
     ) -> None:
         super().__init__(timeout=timeout)
         self.inter = inter
+        self.cleared = False
 
         self.page_loader = page_loader
         self.top_page = top_page
@@ -474,6 +475,7 @@ class QueueCommandView(disnake.ui.View):
     @disnake.ui.button(label='Clear Queue!', style=disnake.ButtonStyle.danger)
     async def clear_queue(self, _: disnake.ui.Button, inter: disnake.MessageInteraction) -> None:
         self.inter.voice_state.songs.clear()
+        self.cleared = True
 
         await inter.response.edit_message(
             'Your queue has been cleared!',
@@ -493,10 +495,11 @@ class QueueCommandView(disnake.ui.View):
         )
 
     async def on_timeout(self) -> None:
-        for child in self.children:
-            child.disabled = True
+        if not self.cleared:
+            for child in self.children:
+                child.disabled = True
 
-        await self.inter.edit_original_message(view=self)
+            await self.inter.edit_original_message(view=self)
 
 
 # The actual cog.

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -17,7 +17,7 @@ from .bot import *
 from .ui import *
 
 # Set version number.
-__version_info__ = ('2023', '4', '7')  # Year.Month.Day
+__version_info__ = ('2023', '4', '24')  # Year.Month.Day
 __version__ = '.'.join(__version_info__)
 
 


### PR DESCRIPTION
### Things changed:

- [x] The `/clearnicks` slash command now directly removes all the nicknames without a button prompt.
- [x] The `/purge` slash command now increments 1 to the given purge amount by default (for proper message deletion).
- [x] Fixed a bug where the view for the `/queue` slash command would reappear after timeout even if a user used the "Clear Queue" button.