### PR TITLE
🔨 [tuning] Improved voice cleanups, restrictions and more

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - develop
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - develop
   pull_request:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
 
 <br> <img src="static/banner.png">
 
-[![CodeQL](https://github.com/IgKniteDev/IgKnite/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/IgKniteDev/IgKnite/actions/workflows/github-code-scanning/codeql)
 [![CodeSee](https://github.com/IgKniteDev/IgKnite/actions/workflows/codesee-arch-diagram.yml/badge.svg)](https://github.com/IgKniteDev/IgKnite/actions/workflows/codesee-arch-diagram.yml)
 [![Format](https://github.com/IgKniteDev/IgKnite/actions/workflows/formatting.yml/badge.svg)](https://github.com/IgKniteDev/IgKnite/actions/workflows/formatting.yml)
 [![Lint](https://github.com/IgKniteDev/IgKnite/actions/workflows/linting.yml/badge.svg)](https://github.com/IgKniteDev/IgKnite/actions/workflows/linting.yml)

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -18,7 +18,7 @@ from disnake.ext import commands
 import core
 
 
-# Backend for ping-labelled commands.
+# Common backend for ping-labelled commands.
 # Do not use it within other commands unless really necessary.
 async def _ping_backend(inter: disnake.CommandInteraction) -> core.TypicalEmbed:
     system_latency = round(inter.bot.latency * 1000)
@@ -88,7 +88,7 @@ class General(commands.Cog):
             )
             await member.send(embed=embed, view=view)
 
-    # Backend for avatar-labelled commands.
+    # Common backend for avatar-labelled commands.
     # Do not use it within other commands unless really necessary.
     async def _avatar_backend(
         self, inter: disnake.CommandInteraction, member: disnake.Member = None

--- a/cogs/inspection.py
+++ b/cogs/inspection.py
@@ -118,7 +118,7 @@ class Inspection(commands.Cog):
 
         await inter.send(embed=embed)
 
-    # Backend for userinfo-labelled commands.
+    # Common backend for userinfo-labelled commands.
     # Do not use it within other commands unless really necessary.
     async def _userinfo_backend(
         self, inter: disnake.CommandInteraction, member: disnake.Member = None

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -46,7 +46,7 @@ class Moderation(commands.Cog):
         await inter.guild.ban(member, reason=reason)
         await inter.send(f'Member **{member.display_name}** has been banned! Reason: {reason}')
 
-    # Backend for softban-labelled commands.
+    # Common backend for softban-labelled commands.
     # Do not use it within other commands unless really necessary.
     async def _softban_backend(
         self,
@@ -191,7 +191,7 @@ class Moderation(commands.Cog):
         else:
             await inter.channel.purge(limit=amount)
 
-    # Backend for ripplepurge-labelled commands.
+    # Common backend for ripplepurge-labelled commands.
     # Do not use it within other commands unless really necessary.
     async def _ripplepurge_backend(
         self,

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -164,15 +164,15 @@ class YTDLSource(disnake.PCMVolumeTransformer):
 
         duration = []
         if days > 0:
-            duration.append(f'{days}d ')
+            duration.append(f'{days}d')
         if hours > 0:
-            duration.append(f'{hours}:')
+            duration.append(f'{hours}h')
         if minutes > 0:
-            duration.append(f'{minutes}:')
+            duration.append(f'{minutes}m')
         if seconds > 0:
-            duration.append(f'{seconds}')
+            duration.append(f'{seconds}s')
 
-        return ''.join(duration)
+        return ' '.join(duration)
 
 
 # YTDLSource class with equalized playback.
@@ -557,8 +557,10 @@ class Music(commands.Cog):
         inter.voice_state = self.init_voice_state(inter)
         return await inter.response.defer()
 
-    async def _ensure_voice_safety(self, inter: disnake.CommandInteraction) -> Any | None:
-        if not inter.voice_state.voice:
+    async def _ensure_voice_safety(
+        self, inter: disnake.CommandInteraction, skip_self: bool = False
+    ) -> Any | None:
+        if (not skip_self) and (not inter.voice_state.voice):
             return await inter.send('I\'m not inside any voice channel.', ephemeral=True)
 
         if not inter.author.voice or inter.author.voice.channel != inter.voice_state.voice.channel:
@@ -650,7 +652,9 @@ class Music(commands.Cog):
         dm_permission=False,
     )
     async def _volume(self, inter: disnake.CommandInteraction, volume: float) -> None:
-        if not inter.voice_state.is_playing:
+        if not await self._ensure_voice_safety(inter):
+            return
+        elif not inter.voice_state.is_playing:
             return await inter.send('There\'s nothing being played at the moment.', ephemeral=True)
 
         inter.voice_state.current.source.volume = (vol_mod := volume / 100)
@@ -658,7 +662,7 @@ class Music(commands.Cog):
 
         await inter.send(
             f'Volume of the player is now set to **{volume}%**'
-            + ('(⚠️ reduced quality) ' if volume > 100 else '')
+            + (' (⚠️ reduced quality) ' if volume > 100 else '')
         )
 
     # now
@@ -671,6 +675,7 @@ class Music(commands.Cog):
         if inter.voice_state.is_playing:
             embed, view = inter.voice_state.current.create_embed(inter)
             await inter.send(embed=embed, view=view)
+
         else:
             await inter.send('There\'s nothing being played at the moment.', ephemeral=True)
 
@@ -736,8 +741,7 @@ class Music(commands.Cog):
     async def _skip(self, inter: disnake.CommandInteraction) -> None:
         if not await self._ensure_voice_safety(inter):
             return
-
-        if not inter.voice_state.is_playing:
+        elif not inter.voice_state.is_playing:
             return await inter.send('There\'s nothing being played at the moment.', ephemeral=True)
 
         if inter.voice_state.loop:
@@ -773,7 +777,9 @@ class Music(commands.Cog):
         name='queue', description='Shows the player\'s queue.', dm_permission=False
     )
     async def _queue(self, inter: disnake.CommandInteraction) -> None:
-        if len(songs := inter.voice_state.songs) == 0:
+        if not await self._ensure_voice_safety(inter):
+            return
+        elif len(songs := inter.voice_state.songs) == 0:
             return await inter.send('The queue is empty.', ephemeral=True)
 
         page = 1
@@ -835,8 +841,7 @@ class Music(commands.Cog):
     async def _rmqueue(self, inter: disnake.CommandInteraction, index: int):
         if not await self._ensure_voice_safety(inter):
             return
-
-        if len(inter.voice_state.songs) == 0:
+        elif len(inter.voice_state.songs) == 0:
             return await inter.send('The queue is empty, so nothing to be removed.', ephemeral=True)
 
         inter.voice_state.songs.remove(index - 1)
@@ -847,6 +852,9 @@ class Music(commands.Cog):
         name='shuffle', description='Shuffles the current queue.', dm_permission=False
     )
     async def _shuffle(self, inter: disnake.CommandInteraction) -> None:
+        if not await self._ensure_voice_safety(inter):
+            return
+
         inter.voice_state.songs.shuffle()
         await inter.send('Shuffled your queue!')
 
@@ -855,10 +863,13 @@ class Music(commands.Cog):
         name='loop', description='Toggles loop for the current song.', dm_permission=False
     )
     async def _loop(self, inter: disnake.CommandInteraction) -> None:
+        if not await self._ensure_voice_safety(inter):
+            return
+
         inter.voice_state.loop = not inter.voice_state.loop
         await inter.send(f"Loop has been {'enabled' if inter.voice_state.loop else 'disabled'}!")
 
-    # Backend for play-labelled commands.
+    # Common backend for play-labelled commands.
     # Do not use it within other commands unless really necessary.
     async def _play_backend(
         self,
@@ -868,9 +879,6 @@ class Music(commands.Cog):
         send_embed: bool = True,
         boosted: bool = False,
     ) -> None:
-        if not inter.voice_state.voice:
-            await self._join_logic(inter)
-
         try:
             source = await (YTDLSource if not boosted else YTDLSourceBoosted).create_source(
                 inter, keyword, loop=self.bot.loop
@@ -918,6 +926,11 @@ class Music(commands.Cog):
     async def _play(
         self, inter: disnake.CommandInteraction, keyword: str, boosted: bool = False
     ) -> None:
+        if not inter.voice_state.voice:
+            await self._join_logic(inter)
+        elif not await self._ensure_voice_safety(inter):
+            return
+
         inter.voice_state.boosted = boosted
 
         async def process_spotify_tracks(ids, tracks) -> None:
@@ -963,13 +976,23 @@ class Music(commands.Cog):
     async def _play_message(
         self, inter: disnake.CommandInteraction, message: disnake.Message
     ) -> None:
+        if not inter.voice_state.voice:
+            await self._join_logic(inter)
+        elif not await self._ensure_voice_safety(inter):
+            return
+
         await self._play_backend(inter, message.content)
 
-    # Backend for play-labelled commands.
+    # Common backend for playrich-labelled commands.
     # Do not use it within other commands unless really necessary.
     async def _playrich_backend(
         self, inter: disnake.CommandInteraction, member: disnake.Member | None = None
     ) -> None:
+        if not inter.voice_state.voice:
+            await self._join_logic(inter)
+        elif not await self._ensure_voice_safety(inter):
+            return
+
         member = member or inter.author
 
         for activity in member.activities:

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -164,15 +164,15 @@ class YTDLSource(disnake.PCMVolumeTransformer):
 
         duration = []
         if days > 0:
-            duration.append(f'{days}d')
+            duration.append(f'{days}')
         if hours > 0:
-            duration.append(f'{hours}h')
+            duration.append(f'{hours}')
         if minutes > 0:
-            duration.append(f'{minutes}m')
+            duration.append(f'{minutes}')
         if seconds > 0:
-            duration.append(f'{seconds}s')
+            duration.append(f'{seconds}')
 
-        return ' '.join(duration)
+        return ':'.join(duration)
 
 
 # YTDLSource class with equalized playback.

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -535,7 +535,11 @@ class Music(commands.Cog):
 
         else:
             if not member.voice:
-                state.voice.cleanup()
+                try:
+                    state.voice.cleanup()
+                except AttributeError:
+                    pass
+
                 await state.stop()
                 del self.voice_states[member.guild.id]
 
@@ -909,7 +913,7 @@ class Music(commands.Cog):
     async def _ensure_play_safety(self, inter: disnake.CommandInteraction) -> True | False:
         if (not inter.voice_state.voice) and (not await self._join_logic(inter)):
             return False
-        elif not await self._ensure_voice_safety(inter):
+        elif not await self._ensure_voice_safety(inter, skip_self=True):
             return False
         else:
             return True

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -509,9 +509,11 @@ class Music(commands.Cog):
     async def on_voice_state_update(
         self, member: disnake.Member, before: disnake.VoiceState, after: disnake.VoiceState
     ) -> None:
+        # Stops the code if there isn't an active voice state assigned to the guild.
         if not (state := self.get_voice_state(member.guild.id)):
             return
 
+        # Ensures fail-safe future playbacks and pause-resume functionality for sudden voice state updates.
         if member != self.bot.user:
             if (
                 before.channel
@@ -557,10 +559,23 @@ class Music(commands.Cog):
         inter.voice_state = self.init_voice_state(inter)
         return await inter.response.defer()
 
-    async def _ensure_voice_safety(self, inter: disnake.CommandInteraction) -> Any | None:
-        if not inter.voice_state.voice:
+    async def _ensure_voice_safety(self, inter: disnake.CommandInteraction, *, skip_self: bool = False) -> Any | None:
+        '''
+        This coroutine ensures that the voice safety of the bot is ensured.
+        Thus, allowing for restricted access to users depending on the bot's voice state.
+
+        Required Parameters:
+        - `inter` (disnake.CommandInteraction): The reference Discord interaction to deal with.
+
+        Optional Parameters:
+        - `skip_self` (bool): Stops the bot from checking its own voice state.
+        '''
+
+        # Checks if the bot is in a voice channel.
+        if (not skip_self) and (not inter.voice_state.voice):
             return await inter.send('I\'m not inside any voice channel.', ephemeral=True)
 
+        # Checks if the author of the interaction is in a voice channel / in the bot's voice channel.
         if not inter.author.voice or inter.author.voice.channel != inter.voice_state.voice.channel:
             return await inter.send('You\'re not in my voice channel.', ephemeral=True)
 
@@ -570,25 +585,24 @@ class Music(commands.Cog):
         self,
         inter: disnake.CommandInteraction,
         channel: disnake.VoiceChannel | disnake.StageChannel | None = None,
-    ) -> Any:
+    ) -> Any | None:
         '''
         A sub-method for commands requiring the bot to join a voice / stage channel.
         '''
 
+        # Stops the code if improper voice safety is found.
+        if not await self._ensure_voice_safety(inter):
+            return
+
+        # Switches to a proper destination (vocal channel).
         destination = channel or (inter.author.voice and inter.author.voice.channel)
 
-        try:
-            if inter.voice_state.voice:
-                await inter.voice_state.voice.move_to(destination)
-            else:
-                inter.voice_state.voice = await destination.connect()
+        if inter.voice_state.voice:
+            await inter.voice_state.voice.move_to(destination)
+        else:
+            inter.voice_state.voice = await destination.connect()
 
-            return destination
-
-        except AttributeError:
-            await inter.send(
-                'Please switch to a voice or stage channel to use this command.', ephemeral=True
-            )
+        return destination
 
     # join
     @commands.slash_command(
@@ -611,7 +625,9 @@ class Music(commands.Cog):
         *,
         channel: disnake.VoiceChannel | disnake.StageChannel | None = None,
     ) -> None:
-        destination = await self._join_logic(inter, channel)
+        if not (destination := await self._join_logic(inter, channel)):
+            return
+
         await inter.send(
             f'Joined **{destination}.**'
             if destination is not channel
@@ -650,6 +666,9 @@ class Music(commands.Cog):
         dm_permission=False,
     )
     async def _volume(self, inter: disnake.CommandInteraction, volume: float) -> None:
+        if not await self._ensure_voice_safety(inter):
+            return
+
         if not inter.voice_state.is_playing:
             return await inter.send('There\'s nothing being played at the moment.', ephemeral=True)
 
@@ -773,6 +792,9 @@ class Music(commands.Cog):
         name='queue', description='Shows the player\'s queue.', dm_permission=False
     )
     async def _queue(self, inter: disnake.CommandInteraction) -> None:
+        if not await self._ensure_voice_safety(inter):
+            return
+
         if len(songs := inter.voice_state.songs) == 0:
             return await inter.send('The queue is empty.', ephemeral=True)
 
@@ -847,6 +869,9 @@ class Music(commands.Cog):
         name='shuffle', description='Shuffles the current queue.', dm_permission=False
     )
     async def _shuffle(self, inter: disnake.CommandInteraction) -> None:
+        if not await self._ensure_voice_safety(inter):
+            return
+
         inter.voice_state.songs.shuffle()
         await inter.send('Shuffled your queue!')
 
@@ -855,6 +880,9 @@ class Music(commands.Cog):
         name='loop', description='Toggles loop for the current song.', dm_permission=False
     )
     async def _loop(self, inter: disnake.CommandInteraction) -> None:
+        if not await self._ensure_voice_safety(inter):
+            return
+
         inter.voice_state.loop = not inter.voice_state.loop
         await inter.send(f"Loop has been {'enabled' if inter.voice_state.loop else 'disabled'}!")
 
@@ -868,8 +896,8 @@ class Music(commands.Cog):
         send_embed: bool = True,
         boosted: bool = False,
     ) -> None:
-        if not inter.voice_state.voice:
-            await self._join_logic(inter)
+        if not await self._join_logic(inter):
+            return
 
         try:
             source = await (YTDLSource if not boosted else YTDLSourceBoosted).create_source(

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -17,7 +17,7 @@ from .bot import *
 from .ui import *
 
 # Set version number.
-__version_info__ = ('2023', '5', '19')  # Year.Month.Day
+__version_info__ = ('2023', '5', '22')  # Year.Month.Day
 __version__ = '.'.join(__version_info__)
 
 


### PR DESCRIPTION
### Things changed:

- [x] Fixed a bug in `play` and `playrich`-labelled commands which allowed outside access from different voice channels.
- [x] More music commands (`/volume`, `/queue`, `/shuffle`, `/loop`) have been locked to the current voice channel.
- [x] Simplified the duration parser for music commands.
- [x] Fixed some improper text indentation inside the `/volume` slash command.
- [x] Formatting and linting workflows now run in the [develop](https://github.com/IgKniteDev/IgKnite/tree/develop) branch as well.