### PR TITLE
🔨 [tuning] Updated the `userinfo` group with latest API changes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,6 +9,7 @@
 		"vscode": {
 			"extensions": [
 				"ms-python.python",
+				"ms-python.vscode-pylance",
 				"charliermarsh.ruff"
 			]
 		}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,10 +5,10 @@
     // List of extensions which should be recommended for users of this workspace.
     "recommendations": [
         "ms-python.python",
+        "ms-python.vscode-pylance",
         "charliermarsh.ruff",
     ],
     "unwantedRecommendations": [	
-        "ms-python.vscode-pylance",
         "ms-python.isort"
     ]
 }

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -11,7 +11,7 @@ from .bot import *
 from .ui import *
 
 # Set version number.
-__version_info__ = ('2023', '6', '21')  # Year.Month.Day
+__version_info__ = ('2023', '6', '23')  # Year.Month.Day
 __version__ = '.'.join(__version_info__)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@
 disnake[voice]==2.9.0
 python-decouple==3.8
 spotipy==2.23.0
-yt-dlp==2023.6.21
+yt-dlp==2023.6.22

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 
-disnake[voice]==2.8.1
+disnake[voice]==2.9.0
 python-decouple==3.8
 spotipy==2.23.0
 yt-dlp==2023.6.21


### PR DESCRIPTION
<!-- SPDX-License-Identifier: MIT -->

### Things changed:

- [x] This PR synchronizes the `/userinfo` group of commands with the latest Discord API changes. It now shows the user's global name and the username in the embed's title section. [(learn more)](https://github.com/DisnakeDev/disnake/releases/tag/v2.9.0)