### PR TITLE
🔨 [tuning] Synchronized `/userinfo` with latest API changes

### DIFF
--- a/cogs/inspection.py
+++ b/cogs/inspection.py
@@ -118,7 +118,7 @@ class Inspection(commands.Cog):
         self, inter: disnake.CommandInteraction, member: disnake.Member
     ) -> None:
         embed = (
-            core.TypicalEmbed(inter=inter, title=str(member))
+            core.TypicalEmbed(inter=inter, title=f'{member.global_name} ({member.display_name})')
             .add_field(name='Status', value=member.status)
             .add_field(
                 name='Birth',


### PR DESCRIPTION
<!-- SPDX-License-Identifier: MIT -->

### Things changed:

This PR modifies the `/userinfo` to display the global name and the username of a user in the title field.