### PR TITLE
✨ [feat] Added `/unassignrole`; tiny, invisible changes & more

### DIFF
--- a/cogs/customization.py
+++ b/cogs/customization.py
@@ -62,9 +62,9 @@ class Customization(commands.Cog):
         color: str = Param(description='Give a color for the new role in Hex.', default='#000000'),
     ) -> None:
         color = get_color(color)
-        await inter.guild.create_role(name=name, color=color)
-
         embed = core.TypicalEmbed(description=f'Role `{name}` has been created.')
+
+        await inter.guild.create_role(name=name, color=color)
         await inter.send(embed=embed)
 
     # assignrole
@@ -80,6 +80,9 @@ class Customization(commands.Cog):
         member: disnake.Member = Param(description='Mention the server member.'),
         role: disnake.Role = Param(description='Mention the role to assign to the user.'),
     ) -> None:
+        if role in member.roles:
+            return await inter.send('The member already has this role.', ephemeral=True)
+
         await member.add_roles(role)
         await inter.send(f'Role {role.mention} has been assigned to **{member.display_name}**!')
 
@@ -96,6 +99,9 @@ class Customization(commands.Cog):
         member: disnake.Member = Param(description='Mention the server member.'),
         role: disnake.Role = Param(description='Mention the role to remove from the user.'),
     ) -> None:
+        if role not in member.roles:
+            return await inter.send('The member doesn\'t has this role.', ephemeral=True)
+
         await member.remove_roles(role)
         await inter.send(f'Role {role.mention} has been removed from **{member.display_name}**!')
 

--- a/cogs/customization.py
+++ b/cogs/customization.py
@@ -45,7 +45,7 @@ class Customization(commands.Cog):
     def __init__(self, bot: core.IgKnite) -> None:
         self.bot = bot
 
-    async def cog_before_slash_command_invoke(self, inter: disnake.CommandInteraction) -> None:
+    async def cog_before_slash_command_invoke(self, inter: disnake.CommandInter) -> None:
         return await inter.response.defer(ephemeral=True)
 
     # makerole
@@ -57,7 +57,7 @@ class Customization(commands.Cog):
     @commands.has_role(LockRoles.admin)
     async def _makerole(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         name: str = Param(description='Give a name for the new role.'),
         color: str = Param(description='Give a color for the new role in Hex.', default='#000000'),
     ) -> None:
@@ -76,7 +76,7 @@ class Customization(commands.Cog):
     @commands.has_role(LockRoles.admin)
     async def _assignrole(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         member: disnake.Member = Param(description='Mention the server member.'),
         role: disnake.Role = Param(description='Mention the role to assign to the user.'),
     ) -> None:
@@ -95,7 +95,7 @@ class Customization(commands.Cog):
     @commands.has_role(LockRoles.admin)
     async def _unassignrole(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         member: disnake.Member = Param(description='Mention the server member.'),
         role: disnake.Role = Param(description='Mention the role to remove from the user.'),
     ) -> None:
@@ -114,7 +114,7 @@ class Customization(commands.Cog):
     @commands.has_role(LockRoles.admin)
     async def _removerole(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         role: disnake.Role = Param(description='Mention the role to delete.'),
     ) -> None:
         await role.delete()
@@ -132,7 +132,7 @@ class Customization(commands.Cog):
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
     async def _makeinvite(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         max_age: int = Param(
             description='Specify a lifetime for the invite in seconds. Defaults to unlimited.',
             default=0,
@@ -172,7 +172,7 @@ class Customization(commands.Cog):
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
     async def _nick(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         member: disnake.Member = Param(description='Mention the server member.'),
         nickname: str = Param(description='Give the nickname to set for the mentioned user.'),
     ) -> None:
@@ -188,7 +188,7 @@ class Customization(commands.Cog):
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
     async def _slowmode(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         duration: int = Param(
             description='The amount of seconds to set the slowmode to. Set 0 to disable.',
             min_value=0,
@@ -212,7 +212,7 @@ class Customization(commands.Cog):
     @commands.has_role(LockRoles.admin)
     async def _makechannel(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         name: str = Param(description='Give a name for the new channel.'),
         category: disnake.CategoryChannel = Param(
             description='Specify the category to put the channel into. Defaults to none.',
@@ -242,7 +242,7 @@ class Customization(commands.Cog):
     @commands.has_role(LockRoles.admin)
     async def _makevc(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         name: str = Param(description='Give a name for the new voice channel.'),
         category: disnake.CategoryChannel = Param(
             description='Specify the category to put the channel into. Defaults to none.',
@@ -271,7 +271,7 @@ class Customization(commands.Cog):
     @commands.has_role(LockRoles.admin)
     async def _makestage(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         name: str = Param(description='Give a name for the new voice channel.'),
         category: disnake.CategoryChannel = Param(
             description='Specify the category to put the channel into. Defaults to none.',
@@ -300,7 +300,7 @@ class Customization(commands.Cog):
     @commands.has_role(LockRoles.admin)
     async def _makecategory(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         name: str = Param(description='Give a name for the new category.'),
     ) -> None:
         category = await inter.guild.create_category(name=name)
@@ -315,7 +315,7 @@ class Customization(commands.Cog):
     @commands.has_role(LockRoles.admin)
     async def _removechannel(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         channel: disnake.TextChannel
         | disnake.VoiceChannel
         | disnake.StageChannel
@@ -337,7 +337,7 @@ class Customization(commands.Cog):
         name='reset', description='Resets the current channel.', dm_permission=False
     )
     @commands.has_role(LockRoles.admin)
-    async def _reset(self, inter: disnake.CommandInteraction) -> None:
+    async def _reset(self, inter: disnake.CommandInter) -> None:
         name = inter.channel.name
         category = inter.channel.category
         topic = inter.channel.topic
@@ -358,7 +358,7 @@ class Customization(commands.Cog):
     @commands.has_role(LockRoles.admin)
     async def _afkvc(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         channel: disnake.VoiceChannel = Param(
             description='Select the AFK channel. Leave blank to create new.',
             default=None,

--- a/cogs/customization.py
+++ b/cogs/customization.py
@@ -83,6 +83,22 @@ class Customization(commands.Cog):
         await member.add_roles(role)
         await inter.send(f'Role {role.mention} has been assigned to **{member.display_name}**!')
 
+    # unassignrole
+    @commands.slash_command(
+        name='unassignrole',
+        description='Removes a role from a server member.',
+        dm_permission=False,
+    )
+    @commands.has_role(LockRoles.admin)
+    async def _unassignrole(
+        self,
+        inter: disnake.CommandInteraction,
+        member: disnake.Member = Param(description='Mention the server member.'),
+        role: disnake.Role = Param(description='Mention the role to remove from the user.'),
+    ) -> None:
+        await member.remove_roles(role)
+        await inter.send(f'Role {role.mention} has been removed from **{member.display_name}**!')
+
     # removerole
     @commands.slash_command(
         name='deleterole',

--- a/cogs/exceptionhandler.py
+++ b/cogs/exceptionhandler.py
@@ -16,7 +16,7 @@ class ExceptionHandler(commands.Cog):
     def __init__(self, bot: core.IgKnite) -> None:
         self.bot = bot
 
-    def get_view(self, inter: disnake.CommandInteraction) -> core.SmallView:
+    def get_view(self, inter: disnake.CommandInter) -> core.SmallView:
         view = core.SmallView(inter).add_button(
             label='Think it\'s a bug?',
             url=core.BotData.repo + '/issues/new?template=bug.yml',
@@ -25,7 +25,7 @@ class ExceptionHandler(commands.Cog):
         return view
 
     @commands.Cog.listener()
-    async def on_slash_command_error(self, inter: disnake.CommandInteraction, error: Any) -> None:
+    async def on_slash_command_error(self, inter: disnake.CommandInter, error: Any) -> None:
         error = getattr(error, 'original', error)
         embed = core.TypicalEmbed(inter=inter, is_error=True)
 
@@ -48,7 +48,7 @@ class ExceptionHandler(commands.Cog):
         await inter.send(embed=embed, view=self.get_view(inter), ephemeral=True)
 
     @commands.Cog.listener()
-    async def on_user_command_error(self, inter: disnake.CommandInteraction, error: Any) -> None:
+    async def on_user_command_error(self, inter: disnake.CommandInter, error: Any) -> None:
         error = getattr(error, 'original', error)
         embed = core.TypicalEmbed(inter=inter, is_error=True)
 
@@ -71,7 +71,7 @@ class ExceptionHandler(commands.Cog):
         await inter.send(embed=embed, view=self.get_view(inter), ephemeral=True)
 
     @commands.Cog.listener()
-    async def on_message_command_error(self, inter: disnake.CommandInteraction, error: Any) -> None:
+    async def on_message_command_error(self, inter: disnake.CommandInter, error: Any) -> None:
         error = getattr(error, 'original', error)
         embed = core.TypicalEmbed(inter=inter, is_error=True)
 

--- a/cogs/exceptionhandler.py
+++ b/cogs/exceptionhandler.py
@@ -18,7 +18,7 @@ class ExceptionHandler(commands.Cog):
 
     def get_view(self, inter: disnake.CommandInteraction) -> core.SmallView:
         view = core.SmallView(inter).add_button(
-            label='It\'s a bug?',
+            label='Think it\'s a bug?',
             url=core.BotData.repo + '/issues/new?template=bug.yml',
             style=disnake.ButtonStyle.red,
         )

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -14,7 +14,7 @@ import core
 
 # Common backend for ping-labelled commands.
 # Do not use it within other commands unless really necessary.
-async def _ping_backend(inter: disnake.CommandInteraction) -> core.TypicalEmbed:
+async def _ping_backend(inter: disnake.CommandInter) -> core.TypicalEmbed:
     system_latency = round(inter.bot.latency * 1000)
 
     start_time = time.time()
@@ -43,7 +43,7 @@ async def _ping_backend(inter: disnake.CommandInteraction) -> core.TypicalEmbed:
 
 # View for the `ping` command.
 class PingCommandView(disnake.ui.View):
-    def __init__(self, inter: disnake.CommandInteraction, *, timeout: float = 60) -> None:
+    def __init__(self, inter: disnake.CommandInter, *, timeout: float = 60) -> None:
         super().__init__(timeout=timeout)
         self.inter = inter
 
@@ -82,7 +82,7 @@ class General(commands.Cog):
     # Common backend for avatar-labelled commands.
     # Do not use it within other commands unless really necessary.
     async def _avatar_backend(
-        self, inter: disnake.CommandInteraction, member: disnake.Member = None
+        self, inter: disnake.CommandInter, member: disnake.Member = None
     ) -> None:
         embed = core.TypicalEmbed(inter=inter, title='Here\'s what I found!').set_image(
             url=member.avatar
@@ -98,7 +98,7 @@ class General(commands.Cog):
     )
     async def _avatar(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         member: disnake.Member = Param(
             description='Mention the server member. Defaults to you.',
             default=lambda inter: inter.author,
@@ -108,18 +108,18 @@ class General(commands.Cog):
 
     # avatar (user)
     @commands.user_command(name='Show Avatar', dm_permission=False)
-    async def _avatar_user(self, inter: disnake.CommandInteraction, member: disnake.Member) -> None:
+    async def _avatar_user(self, inter: disnake.CommandInter, member: disnake.Member) -> None:
         await self._avatar_backend(inter, member)
 
     # ping
     @commands.slash_command(name='ping', description='Shows my current response time.')
-    async def _ping(self, inter: disnake.CommandInteraction) -> None:
+    async def _ping(self, inter: disnake.CommandInter) -> None:
         embed = await _ping_backend(inter)
         await inter.send(embed=embed, view=PingCommandView(inter))
 
     # help
     @commands.slash_command(name='help', description='Get to know IgKnite!')
-    async def help(inter: disnake.CommandInteraction):
+    async def help(inter: disnake.CommandInter):
         embed = core.TypicalEmbed(
             inter,
             title='Hey there! I\'m IgKnite.',

--- a/cogs/inspection.py
+++ b/cogs/inspection.py
@@ -19,7 +19,7 @@ from core.datacls import LockRoles
 class InviteCommandView(disnake.ui.View):
     def __init__(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         *,
         page_loader,
         top_page: int = 1,
@@ -88,7 +88,7 @@ class Inspection(commands.Cog):
         dm_permission=False,
     )
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
-    async def _guildinfo(self, inter: disnake.CommandInteraction) -> None:
+    async def _guildinfo(self, inter: disnake.CommandInter) -> None:
         embed = (
             core.TypicalEmbed(inter=inter)
             .add_field(
@@ -114,9 +114,7 @@ class Inspection(commands.Cog):
 
     # Common backend for userinfo-labelled commands.
     # Do not use it within other commands unless really necessary.
-    async def _userinfo_backend(
-        self, inter: disnake.CommandInteraction, member: disnake.Member
-    ) -> None:
+    async def _userinfo_backend(self, inter: disnake.CommandInter, member: disnake.Member) -> None:
         embed = (
             core.TypicalEmbed(inter=inter, title=f'{member.global_name} ({member.display_name})')
             .add_field(name='Status', value=member.status)
@@ -144,7 +142,7 @@ class Inspection(commands.Cog):
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
     async def _userinfo(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         member: disnake.Member = Param(
             description='Mention the server member. Defaults to you.',
             default=lambda inter: inter.author,
@@ -155,16 +153,14 @@ class Inspection(commands.Cog):
     # userinfo (user)
     @commands.user_command(name='Show User Information', dm_permission=False)
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
-    async def _userinfo_user(
-        self, inter: disnake.CommandInteraction, member: disnake.Member
-    ) -> None:
+    async def _userinfo_user(self, inter: disnake.CommandInter, member: disnake.Member) -> None:
         await self._userinfo_backend(inter, member)
 
     # userinfo (message)
     @commands.message_command(name='Show Author Information', dm_permission=False)
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
     async def _userinfo_message(
-        self, inter: disnake.CommandInteraction, message: disnake.Message
+        self, inter: disnake.CommandInter, message: disnake.Message
     ) -> None:
         await self._userinfo_backend(inter, message.author)
 
@@ -177,7 +173,7 @@ class Inspection(commands.Cog):
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
     async def _roleinfo(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         role: disnake.Role = Param(description='Mention the role.', default=None),
     ) -> None:
         embed = (
@@ -206,7 +202,7 @@ class Inspection(commands.Cog):
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
     async def _invites(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
     ) -> None:
         await inter.response.defer(ephemeral=True)
 
@@ -269,7 +265,7 @@ class Inspection(commands.Cog):
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
     async def _revokeinvites(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         member: disnake.Member = Param(
             description='Mention the server member. Defaults to all.', default=None
         ),
@@ -298,7 +294,7 @@ class Inspection(commands.Cog):
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
     async def _audit(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         limit: int = Param(
             description='The limit for showing audit log entries.',
             default=5,

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -28,7 +28,7 @@ class Moderation(commands.Cog):
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
     async def _ban(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         member: disnake.Member = Param(description='Mention the server member.'),
         reason: str = Param(
             description='Give a reason for the ban.', default='No reason provided.'
@@ -41,7 +41,7 @@ class Moderation(commands.Cog):
     # Do not use it within other commands unless really necessary.
     async def _softban_backend(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         member: disnake.Member,
         *,
         days: int = 7,
@@ -60,7 +60,7 @@ class Moderation(commands.Cog):
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
     async def _softban(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         member: disnake.Member = Param(description='Mention the server member.'),
         reason: str = Param(
             description='Give a reason for the softban.', default='No reason provided.'
@@ -84,9 +84,7 @@ class Moderation(commands.Cog):
     # softban (user)
     @commands.user_command(name='Wipe (Softban)', dm_permission=False)
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
-    async def _softban_user(
-        self, inter: disnake.CommandInteraction, member: disnake.Member
-    ) -> None:
+    async def _softban_user(self, inter: disnake.CommandInter, member: disnake.Member) -> None:
         await self._softban_backend(inter, member)
 
     # kick
@@ -98,7 +96,7 @@ class Moderation(commands.Cog):
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
     async def _kick(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         member: disnake.Member = Param(description='Mention the server member.'),
         reason: str = Param(
             description='Give a reason for the kick.', default='No reason provided.'
@@ -116,7 +114,7 @@ class Moderation(commands.Cog):
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
     async def _timeout(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         member: disnake.Member = Param(description='Mention the server member.'),
         duration: int = Param(
             description='Give a duration for the timeout in seconds. Defaults to 30.',
@@ -139,7 +137,7 @@ class Moderation(commands.Cog):
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
     async def _unban(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         id: int = Param(description='The identifier of the user to unban.', large=True),
         reason: str = Param(
             description='Give a reason for the unban.', default='No reason provided.'
@@ -158,7 +156,7 @@ class Moderation(commands.Cog):
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
     async def _purge(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         amount: int = Param(
             description='The amount of messages to purge. Defaults to 1.', default=1, min_value=1
         ),
@@ -182,7 +180,7 @@ class Moderation(commands.Cog):
     # Do not use it within other commands unless really necessary.
     async def _ripplepurge_backend(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         member: disnake.Member,
         amount: int = 10,
     ) -> None:
@@ -210,7 +208,7 @@ class Moderation(commands.Cog):
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
     async def _ripplepurge(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         member: disnake.Member = Param(description='Mention the server member.'),
         amount: int = Param(
             description='The amount of messages to purge. Defaults to 10.', default=10, min_value=1
@@ -221,16 +219,14 @@ class Moderation(commands.Cog):
     # ripplepurge (user)
     @commands.user_command(name='Ripple Purge', dm_permission=False)
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
-    async def _ripplepurge_user(
-        self, inter: disnake.CommandInteraction, member: disnake.Member
-    ) -> None:
+    async def _ripplepurge_user(self, inter: disnake.CommandInter, member: disnake.Member) -> None:
         await self._ripplepurge_backend(inter, member)
 
     # ripplepurge (message)
     @commands.message_command(name='Ripple Purge', dm_permission=False)
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
     async def _ripplepurge_message(
-        self, inter: disnake.CommandInteraction, message: disnake.Message
+        self, inter: disnake.CommandInter, message: disnake.Message
     ) -> None:
         await self._ripplepurge_backend(inter, message.author)
 
@@ -243,7 +239,7 @@ class Moderation(commands.Cog):
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
     async def _snipe(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         author: disnake.Member = Param(
             description='Mention the author of the messages to snipe. Defaults to none.',
             default=None,
@@ -309,7 +305,7 @@ class Moderation(commands.Cog):
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
     async def senddm(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         member: disnake.Member = Param(description='Mention the server member.'),
         msg: str = Param(description='The message you want to send.'),
     ) -> None:
@@ -332,7 +328,7 @@ class Moderation(commands.Cog):
         description='Shows all pinned messages in the current channel.',
         dm_permission=False,
     )
-    async def _pins(self, inter: disnake.CommandInteraction) -> None:
+    async def _pins(self, inter: disnake.CommandInter) -> None:
         await inter.response.defer()
 
         pins = await inter.channel.pins()
@@ -357,7 +353,7 @@ class Moderation(commands.Cog):
         dm_permission=False,
     )
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
-    async def _clearpins(self, inter: disnake.CommandInteraction) -> None:
+    async def _clearpins(self, inter: disnake.CommandInter) -> None:
         await inter.response.defer(ephemeral=True)
 
         pins = await inter.channel.pins()
@@ -379,7 +375,7 @@ class Moderation(commands.Cog):
     @commands.has_role(LockRoles.admin)
     async def _banword(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         keywords: str = Param(description='The keywords you want to ban, separated by commas.'),
     ) -> None:
         await inter.response.defer(ephemeral=True)
@@ -427,7 +423,7 @@ class Moderation(commands.Cog):
         dm_permission=False,
     )
     @commands.has_role(LockRoles.admin)
-    async def _clearbannedwords(self, inter: disnake.CommandInteraction) -> None:
+    async def _clearbannedwords(self, inter: disnake.CommandInter) -> None:
         await inter.response.defer(ephemeral=True)
 
         try:
@@ -448,7 +444,7 @@ class Moderation(commands.Cog):
         dm_permission=False,
     )
     @commands.has_role(LockRoles.admin)
-    async def _showbannedwords(self, inter: disnake.CommandInteraction) -> None:
+    async def _showbannedwords(self, inter: disnake.CommandInter) -> None:
         await inter.response.defer(ephemeral=True)
 
         try:
@@ -472,7 +468,7 @@ class Moderation(commands.Cog):
         dm_permission=False,
     )
     @commands.has_role(LockRoles.admin)
-    async def _clearnicks(self, inter: disnake.CommandInteraction) -> None:
+    async def _clearnicks(self, inter: disnake.CommandInter) -> None:
         await inter.response.defer(ephemeral=True)
 
         deletion_count = 0

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -7,7 +7,7 @@ import functools
 import itertools
 import math
 import random
-from typing import Any, Self, Tuple
+from typing import Any, Callable, Self, Tuple
 
 import disnake
 import spotipy
@@ -409,7 +409,7 @@ class QueueCommandView(disnake.ui.View):
         self,
         inter: disnake.CommandInteraction,
         *,
-        page_loader,
+        page_loader: Callable,
         top_page: int = 1,
         page: int = 1,
         timeout: float = 60,

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -160,15 +160,15 @@ class YTDLSource(disnake.PCMVolumeTransformer):
 
         duration = []
         if days > 0:
-            duration.append(f'{days}')
+            duration.append(f'{days}d')
         if hours > 0:
-            duration.append(f'{hours}')
+            duration.append(f'{hours}h')
         if minutes > 0:
-            duration.append(f'{minutes}')
+            duration.append(f'{minutes}m')
         if seconds > 0:
-            duration.append(f'{seconds}')
+            duration.append(f'{seconds}s')
 
-        return ':'.join(duration)
+        return ' '.join(duration)
 
 
 # YTDLSource class with equalized playback.

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -905,7 +905,9 @@ class Music(commands.Cog):
 
         except Exception as e:
             if isinstance(e, YTDLError):
-                await inter.send(f'An error occurred while processing this request: {str(e)}')
+                await inter.send(
+                    f'An error occurred while processing this request: {str(e)}', ephemeral=True
+                )
             else:
                 pass
 

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -71,7 +71,7 @@ class YTDLSource(disnake.PCMVolumeTransformer):
 
     def __init__(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         source: disnake.FFmpegPCMAudio,
         *,
         data: dict,
@@ -106,7 +106,7 @@ class YTDLSource(disnake.PCMVolumeTransformer):
     @classmethod
     async def create_source(
         cls,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         search: str,
         *,
         loop: asyncio.BaseEventLoop,
@@ -230,7 +230,7 @@ class Song:
         self.requester = source.requester
 
     def create_embed(
-        self, inter: disnake.CommandInteraction
+        self, inter: disnake.CommandInter
     ) -> Tuple[core.TypicalEmbed, disnake.ui.View]:
         duration = self.source.duration or 'Live'
 
@@ -407,7 +407,7 @@ class NowCommandView(disnake.ui.View):
 class QueueCommandView(disnake.ui.View):
     def __init__(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         *,
         page_loader: Callable,
         top_page: int = 1,
@@ -487,7 +487,7 @@ class Music(commands.Cog):
         for state in self.voice_states.values():
             self.bot.loop.create_task(state.stop())
 
-    def init_voice_state(self, inter: disnake.CommandInteraction) -> VoiceState:
+    def init_voice_state(self, inter: disnake.CommandInter) -> VoiceState:
         '''
         A method that initializes the `VoiceState` object for a specific guild.
         '''
@@ -552,22 +552,22 @@ class Music(commands.Cog):
             elif before.mute and not after.mute and state.voice.is_paused():
                 state.voice.resume()
 
-    async def cog_before_slash_command_invoke(self, inter: disnake.CommandInteraction) -> None:
+    async def cog_before_slash_command_invoke(self, inter: disnake.CommandInter) -> None:
         inter.voice_state = self.init_voice_state(inter)
         return await inter.response.defer()
 
-    async def cog_before_message_command_invoke(self, inter: disnake.CommandInteraction) -> None:
+    async def cog_before_message_command_invoke(self, inter: disnake.CommandInter) -> None:
         inter.voice_state = self.init_voice_state(inter)
         return await inter.response.defer()
 
-    async def cog_before_user_command_invoke(self, inter: disnake.CommandInteraction) -> None:
+    async def cog_before_user_command_invoke(self, inter: disnake.CommandInter) -> None:
         inter.voice_state = self.init_voice_state(inter)
         return await inter.response.defer()
 
     # A coroutine for ensuring proper voice safety during playback.
     async def _ensure_voice_safety(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         *,
         skip_self: bool = False,
         ignore_lock: bool = False,
@@ -596,7 +596,7 @@ class Music(commands.Cog):
     # as needed. Commonly used in play-labelled commands.
     async def _join_logic(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         channel: disnake.VoiceChannel | disnake.StageChannel | None = None,
     ) -> Any | None:
         destination = channel or (inter.author.voice and inter.author.voice.channel)
@@ -621,7 +621,7 @@ class Music(commands.Cog):
     )
     async def _join(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         channel: disnake.VoiceChannel
         | disnake.StageChannel = Param(
             description='Specify a channel to join.',
@@ -642,7 +642,7 @@ class Music(commands.Cog):
         description='Clears the queue and leaves the voice channel.',
         dm_permission=False,
     )
-    async def _leave(self, inter: disnake.CommandInteraction) -> None:
+    async def _leave(self, inter: disnake.CommandInter) -> None:
         if not await self._ensure_voice_safety(inter):
             return
 
@@ -658,7 +658,7 @@ class Music(commands.Cog):
     )
     async def _volume(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         volume: float = Param(
             description='The amount of volume to set in percentage.', min_value=1, max_value=200
         ),
@@ -681,7 +681,7 @@ class Music(commands.Cog):
         name='togglelock', description='Locks / unlocks the current playback.', dm_permission=False
     )
     @commands.has_any_role(LockRoles.mod, LockRoles.admin)
-    async def _lock(self, inter: disnake.CommandInteraction) -> None:
+    async def _lock(self, inter: disnake.CommandInter) -> None:
         if not await self._ensure_voice_safety(inter, ignore_lock=True):
             return
 
@@ -696,7 +696,7 @@ class Music(commands.Cog):
         description='Displays an interactive control view for the current song.',
         dm_permission=False,
     )
-    async def _now(self, inter: disnake.CommandInteraction) -> None:
+    async def _now(self, inter: disnake.CommandInter) -> None:
         if inter.voice_state.is_playing:
             embed, view = inter.voice_state.current.create_embed(inter)
             await inter.send(embed=embed, view=view)
@@ -709,7 +709,7 @@ class Music(commands.Cog):
         description='Pauses the currently playing song.',
         dm_permission=False,
     )
-    async def _pause(self, inter: disnake.CommandInteraction) -> None:
+    async def _pause(self, inter: disnake.CommandInter) -> None:
         if not await self._ensure_voice_safety(inter):
             return
 
@@ -725,7 +725,7 @@ class Music(commands.Cog):
         description='Resumes the currently paused song.',
         dm_permission=False,
     )
-    async def _resume(self, inter: disnake.CommandInteraction) -> None:
+    async def _resume(self, inter: disnake.CommandInter) -> None:
         if not await self._ensure_voice_safety(inter):
             return
 
@@ -741,7 +741,7 @@ class Music(commands.Cog):
         description='Stops playing song and clears the queue.',
         dm_permission=False,
     )
-    async def _stop(self, inter: disnake.CommandInteraction) -> None:
+    async def _stop(self, inter: disnake.CommandInter) -> None:
         if not await self._ensure_voice_safety(inter):
             return
 
@@ -760,7 +760,7 @@ class Music(commands.Cog):
         description='Vote to skip a song. The requester can automatically skip.',
         dm_permission=False,
     )
-    async def _skip(self, inter: disnake.CommandInteraction) -> None:
+    async def _skip(self, inter: disnake.CommandInter) -> None:
         if not await self._ensure_voice_safety(inter):
             return
         elif not inter.voice_state.is_playing:
@@ -798,7 +798,7 @@ class Music(commands.Cog):
     @commands.slash_command(
         name='queue', description='Shows the player\'s queue.', dm_permission=False
     )
-    async def _queue(self, inter: disnake.CommandInteraction) -> None:
+    async def _queue(self, inter: disnake.CommandInter) -> None:
         if not await self._ensure_voice_safety(inter, ignore_lock=True):
             return
         elif len(songs := inter.voice_state.songs) == 0:
@@ -852,7 +852,7 @@ class Music(commands.Cog):
     )
     async def _rmqueue(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         index: int = Param(
             description='Specify the index of the song to remove. Defaults to the first song.',
             default=1,
@@ -870,7 +870,7 @@ class Music(commands.Cog):
     @commands.slash_command(
         name='shuffle', description='Shuffles the current queue.', dm_permission=False
     )
-    async def _shuffle(self, inter: disnake.CommandInteraction) -> None:
+    async def _shuffle(self, inter: disnake.CommandInter) -> None:
         if not await self._ensure_voice_safety(inter, ignore_lock=True):
             return
 
@@ -881,7 +881,7 @@ class Music(commands.Cog):
     @commands.slash_command(
         name='loop', description='Toggles loop for the current song.', dm_permission=False
     )
-    async def _loop(self, inter: disnake.CommandInteraction) -> None:
+    async def _loop(self, inter: disnake.CommandInter) -> None:
         if not await self._ensure_voice_safety(inter):
             return
 
@@ -892,7 +892,7 @@ class Music(commands.Cog):
     # Do not use it within other commands unless really necessary.
     async def _play_backend(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         keyword: str,
         *,
         send_embed: bool = True,
@@ -924,7 +924,7 @@ class Music(commands.Cog):
 
     # Separate coroutine for ensuring voice safety especially for play-labelled commands.
     # Note: This coroutine is used in conjunction with _ensure_voice_safety() and _join_logic().
-    async def _ensure_play_safety(self, inter: disnake.CommandInteraction) -> True | False:
+    async def _ensure_play_safety(self, inter: disnake.CommandInter) -> True | False:
         if (not inter.voice_state.voice) and (not await self._join_logic(inter)):
             return False
         elif not await self._ensure_voice_safety(inter, skip_self=True):
@@ -940,7 +940,7 @@ class Music(commands.Cog):
     )
     async def _play(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         keyword: str = Param(
             description='The link / keyword to search for. Supports YouTube and Spotify links.'
         ),
@@ -992,9 +992,7 @@ class Music(commands.Cog):
 
     # play (message)
     @commands.message_command(name='Search & Play', dm_permission=False)
-    async def _play_message(
-        self, inter: disnake.CommandInteraction, message: disnake.Message
-    ) -> None:
+    async def _play_message(self, inter: disnake.CommandInter, message: disnake.Message) -> None:
         if not await self._ensure_play_safety(inter):
             return
 
@@ -1003,9 +1001,7 @@ class Music(commands.Cog):
     # Common backend for playrich-labelled commands.
     # Do not use it within other commands unless really necessary.
     # Note: This backend is used in conjunction with _play_backend().
-    async def _playrich_backend(
-        self, inter: disnake.CommandInteraction, member: disnake.Member
-    ) -> None:
+    async def _playrich_backend(self, inter: disnake.CommandInter, member: disnake.Member) -> None:
         if not await self._ensure_play_safety(inter):
             return
 
@@ -1033,7 +1029,7 @@ class Music(commands.Cog):
     )
     async def _playrich(
         self,
-        inter: disnake.CommandInteraction,
+        inter: disnake.CommandInter,
         member: disnake.Member = Param(
             description='Mention the server member.', default=lambda inter: inter.author
         ),
@@ -1042,9 +1038,7 @@ class Music(commands.Cog):
 
     # playrich (user)
     @commands.user_command(name='Rich Play', dm_permission=False)
-    async def _playrich_user(
-        self, inter: disnake.CommandInteraction, member: disnake.Member
-    ) -> None:
+    async def _playrich_user(self, inter: disnake.CommandInter, member: disnake.Member) -> None:
         await self._playrich_backend(inter, member)
 
 

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -552,17 +552,20 @@ class Music(commands.Cog):
             elif before.mute and not after.mute and state.voice.is_paused():
                 state.voice.resume()
 
-    async def cog_before_slash_command_invoke(self, inter: disnake.CommandInter) -> None:
+    # A coroutine for setting the common logic behind the three before-invocation functions
+    # which have been modified below.
+    async def _app_command_invoke_logic(self, inter: disnake.CommandInter) -> None:
         inter.voice_state = self.init_voice_state(inter)
         return await inter.response.defer()
+
+    async def cog_before_slash_command_invoke(self, inter: disnake.CommandInter) -> None:
+        await self._app_command_invoke_logic(inter)
 
     async def cog_before_message_command_invoke(self, inter: disnake.CommandInter) -> None:
-        inter.voice_state = self.init_voice_state(inter)
-        return await inter.response.defer()
+        await self._app_command_invoke_logic(inter)
 
     async def cog_before_user_command_invoke(self, inter: disnake.CommandInter) -> None:
-        inter.voice_state = self.init_voice_state(inter)
-        return await inter.response.defer()
+        await self._app_command_invoke_logic(inter)
 
     # A coroutine for ensuring proper voice safety during playback.
     async def _ensure_voice_safety(
@@ -592,8 +595,8 @@ class Music(commands.Cog):
         else:
             return True
 
-    # A coroutine for commands which sets the destination voice channel of the bot
-    # as needed. Commonly used in play-labelled commands.
+    # A coroutine for commands which sets the destination voice channel of the bot as needed.
+    # Commonly used in play-labelled commands.
     async def _join_logic(
         self,
         inter: disnake.CommandInter,

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -965,7 +965,7 @@ class Music(commands.Cog):
             for track in tracks:
                 await self._play_backend(inter, track, send_embed=False, boosted=boosted)
 
-            embed = core.TypicalEmbed(inter=inter, title=f'{len(tracks)} tracks have been queued!')
+            embed = core.TypicalEmbed(inter=inter, title='The tracks have been enqueued!')
             await inter.send(embed=embed)
 
         if 'https://open.spotify.com/playlist/' in keyword or 'spotify:playlist:' in keyword:

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -11,7 +11,7 @@ from .bot import *
 from .ui import *
 
 # Set version number.
-__version_info__ = ('2023', '6', '23')  # Year.Month.Day
+__version_info__ = ('2023', '7', '13')  # Year.Month.Day
 __version__ = '.'.join(__version_info__)
 
 

--- a/core/ui.py
+++ b/core/ui.py
@@ -17,7 +17,7 @@ class TypicalEmbed(disnake.Embed):
     def __init__(
         self,
         *args,
-        inter: disnake.CommandInteraction | None = None,
+        inter: disnake.CommandInter | None = None,
         disabled_footer: bool = False,
         is_error: bool = False,
         **kwargs,
@@ -52,9 +52,7 @@ class SmallView(disnake.ui.View):
     Can be used for simple views with buttons.
     '''
 
-    def __init__(
-        self, inter: disnake.CommandInteraction | None = None, *, timeout: float = 60
-    ) -> None:
+    def __init__(self, inter: disnake.CommandInter | None = None, *, timeout: float = 60) -> None:
         super().__init__(timeout=timeout)
         self.inter = inter
 


### PR DESCRIPTION
<!-- SPDX-License-Identifier: MIT -->

### Things changed:

- [x] Added a new `/unassignrole` slash command which can be used to remove a role from a given server member.
- [x] Both `/assignrole` and `unassignrole` now include member-based checks within them.
- [x] Parts of the music system's warnings are now ephemeral.
- [x] Tiny changes to the type hinting and command embeds have been made all over the codebase.
- [x] Reduced a small amount of repetitive code.