### PR TITLE
✨ [feat] Added automatic reboots for HTTP exceptions

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -11,7 +11,7 @@ from .bot import *
 from .ui import *
 
 # Set version number.
-__version_info__ = ('2023', '8', '8')  # Year.Month.Day
+__version_info__ = ('2023', '8', '25')  # Year.Month.Day
 __version__ = '.'.join(__version_info__)
 
 

--- a/main.py
+++ b/main.py
@@ -2,6 +2,8 @@
 
 
 # Imports.
+from os import system
+
 import disnake
 
 import core
@@ -23,4 +25,7 @@ bot = core.IgKnite(
 
 # Run!
 if __name__ == '__main__':
-    bot.run(keychain.discord_token)
+    try:
+        bot.run(keychain.discord_token)
+    except disnake.errors.HTTPException:
+        system('python reboot.py && kill 1')

--- a/reboot.py
+++ b/reboot.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: MIT
+
+
+# Imports.
+from os import system
+from time import sleep
+
+# This script acts as an automatic solution for restarting IgKnite in
+# the event of an HTTP exception.
+print('Blocked by HTTP exception, rebooting in 10 seconds...')
+sleep(10)
+system('python main..py')

--- a/reboot.py
+++ b/reboot.py
@@ -9,4 +9,4 @@ from time import sleep
 # the event of an HTTP exception.
 print('Blocked by HTTP exception, rebooting in 10 seconds...')
 sleep(10)
-system('python main..py')
+system('python main.py')


### PR DESCRIPTION
<!-- SPDX-License-Identifier: MIT -->

### Things changed:

This PR adds a new `reboot.py` Python script that can be used to restart the bot automatically in the event of a possible HTTP exception / rate-limit indication.