### PR TITLE
🐛 [bugfix] Bookmarking doesn't rely on internal cache anymore

### DIFF
--- a/cogs/general.py
+++ b/cogs/general.py
@@ -67,20 +67,17 @@ class General(commands.Cog):
     # Listener for the bookmark feature.
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload: disnake.RawReactionActionEvent) -> None:
-        if payload.emoji.name == '🔖':
-            if payload.event_type == 'REACTION_ADD':
-                chnl = self.bot.get_channel(payload.channel_id)
-                msg = disnake.utils.get(
-                    await chnl.history(limit=5).flatten(), id=payload.message_id
-                )
-                embed = core.TypicalEmbed(
-                    title='You\'ve bookmarked a message.',
-                    description=msg.content
-                    + f'\n\nSent by {msg.author.name} '
-                    + f'on {payload.member.guild.name}',
-                )
-                view = core.SmallView().add_button(label='Original Message', url=msg.jump_url)
-                await payload.member.send(embed=embed, view=view)
+        if payload.emoji.name == '🔖' and payload.event_type == 'REACTION_ADD':
+            chnl = self.bot.get_channel(payload.channel_id)
+            msg = disnake.utils.get(await chnl.history(limit=5).flatten(), id=payload.message_id)
+            embed = core.TypicalEmbed(
+                title='You\'ve bookmarked a message.',
+                description=msg.content
+                + f'\n\nSent by {msg.author.name} '
+                + f'on {payload.member.guild.name}',
+            )
+            view = core.SmallView().add_button(label='Original Message', url=msg.jump_url)
+            await payload.member.send(embed=embed, view=view)
 
     # Common backend for avatar-labelled commands.
     # Do not use it within other commands unless really necessary.

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -66,18 +66,21 @@ class General(commands.Cog):
 
     # Listener for the bookmark feature.
     @commands.Cog.listener()
-    async def on_reaction_add(self, reaction: disnake.Reaction, member: disnake.Member) -> None:
-        if reaction.emoji == '🔖':
-            embed = core.TypicalEmbed(
-                title='You\'ve bookmarked a message.',
-                description=reaction.message.content
-                + f'\n\nSent by {reaction.message.author.name} '
-                + f'on {member.guild.name}',
-            )
-            view = core.SmallView().add_button(
-                label='Original Message', url=reaction.message.jump_url
-            )
-            await member.send(embed=embed, view=view)
+    async def on_raw_reaction_add(self, payload: disnake.RawReactionActionEvent) -> None:
+        if payload.emoji.name == '🔖':
+            if payload.event_type == 'REACTION_ADD':
+                chnl = self.bot.get_channel(payload.channel_id)
+                msg = disnake.utils.get(await chnl.history(limit=5).flatten(), id=payload.message_id)
+                embed = core.TypicalEmbed(
+                    title='You\'ve bookmarked a message.',
+                    description=msg.content
+                    + f'\n\nSent by {msg.author.name} '
+                    + f'on {payload.member.guild.name}',
+                )
+                view = core.SmallView().add_button(
+                    label='Original Message', url=msg.jump_url
+                )
+                await payload.member.send(embed=embed, view=view)
 
     # Common backend for avatar-labelled commands.
     # Do not use it within other commands unless really necessary.
@@ -119,7 +122,7 @@ class General(commands.Cog):
 
     # help
     @commands.slash_command(name='help', description='Get to know IgKnite!')
-    async def help(inter: disnake.CommandInter):
+    async def help(self, inter: disnake.CommandInter):
         embed = core.TypicalEmbed(
             inter,
             title='Hey there! I\'m IgKnite.',

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -70,16 +70,16 @@ class General(commands.Cog):
         if payload.emoji.name == '🔖':
             if payload.event_type == 'REACTION_ADD':
                 chnl = self.bot.get_channel(payload.channel_id)
-                msg = disnake.utils.get(await chnl.history(limit=5).flatten(), id=payload.message_id)
+                msg = disnake.utils.get(
+                    await chnl.history(limit=5).flatten(), id=payload.message_id
+                )
                 embed = core.TypicalEmbed(
                     title='You\'ve bookmarked a message.',
                     description=msg.content
                     + f'\n\nSent by {msg.author.name} '
                     + f'on {payload.member.guild.name}',
                 )
-                view = core.SmallView().add_button(
-                    label='Original Message', url=msg.jump_url
-                )
+                view = core.SmallView().add_button(label='Original Message', url=msg.jump_url)
                 await payload.member.send(embed=embed, view=view)
 
     # Common backend for avatar-labelled commands.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ disnake[voice]==2.9.1
 python-decouple==3.8
 spotipy==2.23.0
 yt-dlp==2023.11.16
+async-timeout==4.0.3


### PR DESCRIPTION
<!-- SPDX-License-Identifier: MIT -->

### Things changed:
- [x] Switched from `on_reaction_add` to `on_raw_reaction_add` because the former relied on an internal cache which got reset on every restart, causing the bookmarking feature to not work on older messages.
- [x] Updated `requirements.txt` to include the following essential standalone dependency:  `async-timeout==4.0.3` (I'm pretty sure this was supposed to be automatic, but somehow it didn't work I suppose)
