### PR TITLE
✨ [feat] Better _ensure_voice_safety() with improved locks

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 {
 	"name": "Python 3",
 	"image": "mcr.microsoft.com/devcontainers/python:0-3.11",
-	"postCreateCommand": "sudo apt update && sudo apt install -y --no-install-recommends ffmpeg && pip install -U pip && pip install -r requirements.txt && pip install black ruff",
+	"postCreateCommand": "sudo apt update && sudo apt install -y --no-install-recommends ffmpeg && pip install -U pip && pip install -r requirements.txt && pip install ruff",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@
 <br> <img src="static/banner.png">
 
 [![CodeSee](https://github.com/IgKniteDev/IgKnite/actions/workflows/codesee-arch-diagram.yml/badge.svg)](https://github.com/IgKniteDev/IgKnite/actions/workflows/codesee-arch-diagram.yml)
-[![Style Check](https://github.com/IgKniteDev/IgKnite/actions/workflows/stylecheck.yml/badge.svg)](https://github.com/IgKniteDev/IgKnite/actions/workflows/stylecheck.yml)
+[![Formatting](https://github.com/IgKniteDev/IgKnite/actions/workflows/formatting.yml/badge.svg)](https://github.com/IgKniteDev/IgKnite/actions/workflows/formatting.yml)
+[![Linting](https://github.com/IgKniteDev/IgKnite/actions/workflows/linting.yml/badge.svg)](https://github.com/IgKniteDev/IgKnite/actions/workflows/linting.yml)
+
 
 </div>
 


### PR DESCRIPTION
<!-- SPDX-License-Identifier: MIT -->

### Things changed:

- [ ] (untested) This PR introduces a new `skip_play` flag to the internal `_ensure_voice_safety()` method of the Music cog to check if there is actually something that's loaded onto the memory regardless of whether it's paused or not. This has a whole range of usage benefits and actually solves several commands which had previously stopped working due to the music being paused.
- [x] Fixed broken GitHub Actions status badges in the README.md file.