### PR TITLE
🔨 [tuning] Add new deployment workflows

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 
-name: Create, Publish & Deploy Docker Image
+name: Publish Docker Image
 
 on:
   release:

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,0 +1,18 @@
+# See https://fly.io/docs/app-guides/continuous-deployment-with-github-actions/
+
+name: Fly Deploy
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    name: Deploy app
+    runs-on: ubuntu-latest
+    concurrency: deploy-group    # optional: ensure only one action runs at a time
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,20 @@
+# fly.toml app configuration file generated for igknite on 2024-09-30T19:16:03+06:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'igknite'
+primary_region = 'sin'
+
+[build]
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+[[vm]]
+  size = 'shared-cpu-1x'


### PR DESCRIPTION
<!-- SPDX-License-Identifier: MIT -->

### Things changed:

- [x] The deployment workflow now uses [fly.io](https://fly.io/) for hosting the pre-hosted default instance of IgKnite.